### PR TITLE
Add MCP Server one-click deploy toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The public command surface is constrained to the v1 plan:
 - `revx brief <query>`
 - `revx report generate <topic>`
 - `revx trace import <file>`
-- `revx mcp serve`
+- `revx mcp serve|doctor|config|install`
 
 ## Workspace authority
 
@@ -112,6 +112,30 @@ The high-level MCP tools are:
 - `analysis_brief`
 - `trace_import`
 - `trace_query`
+
+## MCP Server deploy
+
+ReVX ships as an **MCP Server** (`revx-engine mcp serve`). An MCP **Host** (Codex / Cursor / Claude Desktop) spawns that process over stdio. The CLI binary is the deploy/entrypoint and human interface, not the Host.
+
+One-click install + config samples:
+
+```bash
+./deploy/mcp/one-click.sh
+```
+
+Then point the Host at:
+
+```bash
+~/.local/bin/revx-engine mcp serve --workspace /path/to/project
+```
+
+Details, host templates, and doctor checks: [deploy/mcp/README.md](deploy/mcp/README.md).
+
+```bash
+revx-engine mcp doctor --workspace .
+revx-engine mcp config --host cursor --workspace .
+revx mcp serve --workspace .   # thin CLI forwards to engine
+```
 
 ## Build and smoke
 

--- a/crates/revx-engine/src/main.rs
+++ b/crates/revx-engine/src/main.rs
@@ -583,9 +583,46 @@ enum DaemonCommands {
     Stop,
 }
 
+#[derive(ValueEnum, Clone, Copy, Debug)]
+enum McpHost {
+    Generic,
+    Cursor,
+    Claude,
+    Codex,
+}
+
 #[derive(Subcommand)]
 enum McpCommands {
-    Serve,
+    Serve {
+        #[arg(long, short = 'C')]
+        workspace: Option<PathBuf>,
+        #[arg(long, default_value_t = false)]
+        init: bool,
+    },
+    Doctor {
+        #[arg(long, short = 'C')]
+        workspace: Option<PathBuf>,
+    },
+    Config {
+        #[arg(long, value_enum, default_value_t = McpHost::Generic)]
+        host: McpHost,
+        #[arg(long, short = 'C')]
+        workspace: Option<PathBuf>,
+        #[arg(long)]
+        bin: Option<PathBuf>,
+    },
+    Install {
+        #[arg(long)]
+        prefix: Option<PathBuf>,
+        #[arg(long, short = 'C')]
+        workspace: Option<PathBuf>,
+        #[arg(long, value_enum)]
+        host: Vec<McpHost>,
+        #[arg(long, default_value_t = false)]
+        write_config: bool,
+        #[arg(long, default_value_t = false)]
+        init_workspace: bool,
+    },
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -657,7 +694,22 @@ async fn main() -> Result<()> {
         Command::Daemon(DaemonCommands::Start) => cmd_daemon_start().await,
         Command::Daemon(DaemonCommands::Status) => cmd_daemon_status(),
         Command::Daemon(DaemonCommands::Stop) => cmd_daemon_stop(),
-        Command::Mcp(McpCommands::Serve) => cmd_mcp_serve().await,
+        Command::Mcp(McpCommands::Serve { workspace, init }) => {
+            cmd_mcp_serve(workspace, init).await
+        }
+        Command::Mcp(McpCommands::Doctor { workspace }) => cmd_mcp_doctor(workspace),
+        Command::Mcp(McpCommands::Config {
+            host,
+            workspace,
+            bin,
+        }) => cmd_mcp_config(host, workspace, bin),
+        Command::Mcp(McpCommands::Install {
+            prefix,
+            workspace,
+            host,
+            write_config,
+            init_workspace,
+        }) => cmd_mcp_install(prefix, workspace, host, write_config, init_workspace),
     }
 }
 
@@ -1195,9 +1247,268 @@ fn cmd_daemon_stop() -> Result<()> {
     Ok(())
 }
 
-async fn cmd_mcp_serve() -> Result<()> {
-    let workspace_dir = workspace_parent_from_cwd()?;
-    serve_mcp_stdio(workspace_dir).await
+async fn cmd_mcp_serve(workspace: Option<PathBuf>, init: bool) -> Result<()> {
+    let project = resolve_mcp_project_root(workspace, init)?;
+    serve_mcp_stdio(project).await
+}
+
+fn cmd_mcp_doctor(workspace: Option<PathBuf>) -> Result<()> {
+    let exe = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("revx-engine"));
+    println!("revx-engine: {}", exe.display());
+    println!("version: {}", env!("CARGO_PKG_VERSION"));
+    match resolve_mcp_project_root(workspace, false) {
+        Ok(project) => {
+            let revx = project.join(".revx");
+            println!("workspace: {}", project.display());
+            println!("revx_dir: {}", revx.display());
+            println!("project_toml: {}", revx.join("project.toml").exists());
+            println!("state_sqlite: {}", revx.join("state.sqlite").exists());
+            match Workspace::open(&project) {
+                Ok(ws) => match ws.project_config() {
+                    Ok(cfg) => {
+                        println!("schema_version: {}", cfg.schema_version);
+                        println!("project_name: {}", cfg.name);
+                        println!("status: ok");
+                    }
+                    Err(err) => {
+                        println!("status: workspace_open_ok_config_error");
+                        println!("error: {err:#}");
+                    }
+                },
+                Err(err) => {
+                    println!("status: workspace_error");
+                    println!("error: {err:#}");
+                }
+            }
+        }
+        Err(err) => {
+            println!("workspace: unresolved");
+            println!("status: missing_workspace");
+            println!("error: {err:#}");
+            println!("hint: revx-engine mcp serve --workspace <path> --init");
+        }
+    }
+    Ok(())
+}
+
+fn cmd_mcp_config(
+    host: McpHost,
+    workspace: Option<PathBuf>,
+    bin: Option<PathBuf>,
+) -> Result<()> {
+    let engine = resolve_engine_bin(bin)?;
+    let project = match workspace {
+        Some(path) => canonicalize_path(&path)?,
+        None => match resolve_mcp_project_root(None, false) {
+            Ok(path) => path,
+            Err(_) => std::env::current_dir()?,
+        },
+    };
+    print!("{}", render_mcp_host_config(host, &engine, &project));
+    Ok(())
+}
+
+fn cmd_mcp_install(
+    prefix: Option<PathBuf>,
+    workspace: Option<PathBuf>,
+    hosts: Vec<McpHost>,
+    write_config: bool,
+    init_workspace: bool,
+) -> Result<()> {
+    let prefix = expand_user_path(prefix.unwrap_or_else(default_install_prefix))?;
+    let bin_dir = prefix.join("bin");
+    let conf_dir = prefix.join("share/revx/mcp");
+    fs::create_dir_all(&bin_dir)?;
+    fs::create_dir_all(&conf_dir)?;
+
+    let current = std::env::current_exe().context("failed to resolve current executable")?;
+    let engine_dst = bin_dir.join("revx-engine");
+    fs::copy(&current, &engine_dst).with_context(|| {
+        format!(
+            "failed to install {} -> {}",
+            current.display(),
+            engine_dst.display()
+        )
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&engine_dst)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&engine_dst, perms)?;
+    }
+
+    let project = resolve_mcp_project_root(workspace, init_workspace).unwrap_or_else(|_| {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    });
+    if init_workspace && !project.join(".revx").exists() {
+        let _ = resolve_mcp_project_root(Some(project.clone()), true)?;
+    }
+
+    let host_list = if hosts.is_empty() {
+        vec![
+            McpHost::Generic,
+            McpHost::Cursor,
+            McpHost::Claude,
+            McpHost::Codex,
+        ]
+    } else {
+        hosts
+    };
+
+    println!("installed: {}", engine_dst.display());
+    println!("workspace: {}", project.display());
+
+    for host in host_list {
+        let body = render_mcp_host_config(host, &engine_dst, &project);
+        let name = match host {
+            McpHost::Generic => "generic.mcp.json",
+            McpHost::Cursor => "cursor.mcp.json",
+            McpHost::Claude => "claude_desktop.mcp.json",
+            McpHost::Codex => "codex.mcp.json",
+        };
+        let path = conf_dir.join(name);
+        if write_config {
+            fs::write(&path, &body)?;
+            println!("config: {}", path.display());
+        } else {
+            println!("--- {} ---", name);
+            print!("{body}");
+        }
+    }
+
+    println!("serve: {} mcp serve --workspace {}", engine_dst.display(), project.display());
+    println!("doctor: {} mcp doctor --workspace {}", engine_dst.display(), project.display());
+    Ok(())
+}
+
+fn default_install_prefix() -> PathBuf {
+    home_dir()
+        .map(|h| h.join(".local"))
+        .unwrap_or_else(|| PathBuf::from(".revx-install"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+}
+
+fn expand_user_path(path: PathBuf) -> Result<PathBuf> {
+    let raw = path.to_string_lossy();
+    if raw == "~" {
+        return home_dir().context("HOME not set");
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        let home = home_dir().context("HOME not set")?;
+        return Ok(home.join(rest));
+    }
+    Ok(path)
+}
+
+fn resolve_engine_bin(bin: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(path) = bin {
+        return canonicalize_path(&path);
+    }
+    if let Some(path) = std::env::var_os("REVX_ENGINE") {
+        return canonicalize_path(Path::new(&path));
+    }
+    if let Ok(path) = std::env::current_exe() {
+        return canonicalize_path(&path);
+    }
+    Ok(PathBuf::from("revx-engine"))
+}
+
+fn canonicalize_path(path: &Path) -> Result<PathBuf> {
+    if path.exists() {
+        return path
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize {}", path.display()));
+    }
+    Ok(path.to_path_buf())
+}
+
+fn resolve_mcp_project_root(workspace: Option<PathBuf>, init: bool) -> Result<PathBuf> {
+    let project = if let Some(path) = workspace {
+        let path = expand_user_path(path)?;
+        if path.join(".revx").exists() {
+            canonicalize_path(&path)?
+        } else if path.file_name().and_then(|s| s.to_str()) == Some(".revx") {
+            path.parent()
+                .map(|p| p.to_path_buf())
+                .context("invalid .revx path")?
+        } else {
+            path
+        }
+    } else {
+        match workspace_parent_from_cwd() {
+            Ok(path) => path,
+            Err(_) => std::env::current_dir()?,
+        }
+    };
+
+    let project = if project.exists() {
+        canonicalize_path(&project).unwrap_or(project)
+    } else {
+        project
+    };
+
+    if init && !project.join(".revx").exists() {
+        fs::create_dir_all(&project)?;
+        let name = project
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "revx-project".to_string());
+        Workspace::init(&project, &name, None)?;
+    }
+
+    if !project.join(".revx").exists() {
+        anyhow::bail!(
+            "no revx workspace at {} (missing .revx). Use --workspace and/or --init",
+            project.display()
+        );
+    }
+    Ok(project)
+}
+
+fn render_mcp_host_config(host: McpHost, engine: &Path, workspace: &Path) -> String {
+    let engine_s = engine.display().to_string();
+    let workspace_s = workspace.display().to_string();
+    match host {
+        McpHost::Generic | McpHost::Codex => serde_json::json!({
+            "mcpServers": {
+                "revx": {
+                    "command": engine_s,
+                    "args": ["mcp", "serve", "--workspace", workspace_s],
+                }
+            }
+        })
+        .to_string()
+            + "
+",
+        McpHost::Cursor => serde_json::json!({
+            "mcpServers": {
+                "revx": {
+                    "command": engine_s,
+                    "args": ["mcp", "serve", "--workspace", workspace_s]
+                }
+            }
+        })
+        .to_string()
+            + "
+",
+        McpHost::Claude => serde_json::json!({
+            "mcpServers": {
+                "revx": {
+                    "command": engine_s,
+                    "args": ["mcp", "serve", "--workspace", workspace_s]
+                }
+            }
+        })
+        .to_string()
+            + "
+",
+    }
 }
 
 fn workspace_from_cwd() -> Result<Workspace> {

--- a/deploy/mcp/README.md
+++ b/deploy/mcp/README.md
@@ -1,0 +1,96 @@
+# ReVX MCP Server deploy
+
+ReVX is an **MCP Server**. The **MCP Host** (Codex, Cursor, Claude Desktop, …) launches it.
+
+```text
+Host (Codex / Cursor / …)
+  └── spawn command/args (stdio JSON-RPC)
+        └── revx-engine mcp serve --workspace <project>
+```
+
+`revx` / `revx-engine` CLI is the **deploy entrypoint and human CLI**, not the Host.
+
+## One-click
+
+From the repository root (or any dir with this tree):
+
+```bash
+./deploy/mcp/one-click.sh
+```
+
+Environment:
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `REVX_PREFIX` | `~/.local` | install prefix (`bin/`, `share/revx/mcp/`) |
+| `REVX_WORKSPACE` | cwd if `.revx` exists, else repo root | analysis workspace project dir |
+| `REVX_INIT_WORKSPACE` | `1` for one-click | create `.revx` if missing |
+| `REVX_ENGINE` | auto | override engine binary path |
+
+What it does:
+
+1. `cargo build -p revx -p revx-engine --release`
+2. `revx-engine mcp install --write-config …` → `~/.local/bin/revx-engine` + host config samples
+3. `mcp doctor` health check
+4. prints a ready-to-paste MCP config
+
+## Manual start (stdio)
+
+Hosts should spawn this (do not wrap in extra shells for production configs):
+
+```bash
+revx-engine mcp serve --workspace /path/to/project
+```
+
+Helper for local smoke:
+
+```bash
+./deploy/mcp/start-mcp.sh
+```
+
+## Other helpers
+
+```bash
+./deploy/mcp/doctor.sh
+./deploy/mcp/print-config.sh generic
+./deploy/mcp/print-config.sh cursor
+./deploy/mcp/print-config.sh claude
+./deploy/mcp/print-config.sh codex
+```
+
+## Engine commands
+
+```bash
+revx-engine mcp serve [--workspace PATH] [--init]
+revx-engine mcp doctor [--workspace PATH]
+revx-engine mcp config --host generic|cursor|claude|codex [--workspace PATH] [--bin PATH]
+revx-engine mcp install [--prefix PATH] [--workspace PATH] [--write-config] [--init-workspace]
+```
+
+Thin CLI forwards: `revx mcp …` → `revx-engine mcp …`.
+
+## Host wiring
+
+1. Run `./deploy/mcp/one-click.sh`
+2. Open `~/.local/share/revx/mcp/*.json` (or stdout from `print-config.sh`)
+3. Merge the `mcpServers.revx` block into your Host config
+4. Restart the Host
+5. Confirm tools such as `project_status`, `function_search`, `decompile_function`
+
+### Cursor
+
+Merge into Cursor MCP settings (often `mcp.json`). Template: `templates/cursor.mcp.json`.
+
+### Claude Desktop
+
+Merge into Claude Desktop config `mcpServers`. Template: `templates/claude_desktop.mcp.json`.
+
+### Codex
+
+Merge into Codex MCP server settings. Template: `templates/codex.mcp.json`.
+
+## Notes
+
+- stdout is the MCP protocol stream; logs must stay on stderr
+- workspace path is the project directory that contains `.revx/`
+- optional long-lived analysis daemon (`revx daemon start`) is separate from MCP stdio lifecycle

--- a/deploy/mcp/doctor.sh
+++ b/deploy/mcp/doctor.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+WORKSPACE="$(revx_default_workspace)"
+if ! ENGINE="$(revx_resolve_engine)"; then
+  echo "error: revx-engine not found. Run deploy/mcp/one-click.sh first." >&2
+  exit 1
+fi
+
+"$ENGINE" mcp doctor --workspace "$WORKSPACE"
+echo
+echo "config (generic):"
+"$ENGINE" mcp config --host generic --workspace "$WORKSPACE" --bin "$ENGINE"

--- a/deploy/mcp/lib.sh
+++ b/deploy/mcp/lib.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+revx_deploy_root() {
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  cd "$here/../.." && pwd
+}
+
+revx_repo_root() {
+  revx_deploy_root
+}
+
+revx_default_prefix() {
+  echo "${REVX_PREFIX:-$HOME/.local}"
+}
+
+revx_default_workspace() {
+  if [[ -n "${REVX_WORKSPACE:-}" ]]; then
+    echo "$REVX_WORKSPACE"
+    return
+  fi
+  if [[ -d "$PWD/.revx" ]]; then
+    pwd
+    return
+  fi
+  echo "$(revx_repo_root)"
+}
+
+revx_resolve_engine() {
+  if [[ -n "${REVX_ENGINE:-}" && -x "${REVX_ENGINE}" ]]; then
+    echo "$REVX_ENGINE"
+    return
+  fi
+  local prefix bin repo
+  prefix="$(revx_default_prefix)"
+  bin="$prefix/bin/revx-engine"
+  if [[ -x "$bin" ]]; then
+    echo "$bin"
+    return
+  fi
+  repo="$(revx_repo_root)"
+  if [[ -x "$repo/target/release/revx-engine" ]]; then
+    echo "$repo/target/release/revx-engine"
+    return
+  fi
+  if [[ -x "$repo/target/debug/revx-engine" ]]; then
+    echo "$repo/target/debug/revx-engine"
+    return
+  fi
+  if command -v revx-engine >/dev/null 2>&1; then
+    command -v revx-engine
+    return
+  fi
+  return 1
+}
+
+revx_build_release() {
+  local repo
+  repo="$(revx_repo_root)"
+  (cd "$repo" && cargo build -p revx -p revx-engine --release)
+}

--- a/deploy/mcp/one-click.sh
+++ b/deploy/mcp/one-click.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PREFIX="$(revx_default_prefix)"
+WORKSPACE="$(revx_default_workspace)"
+INIT_WS="${REVX_INIT_WORKSPACE:-1}"
+
+echo "[revx-mcp] repo=$(revx_repo_root)"
+echo "[revx-mcp] prefix=$PREFIX"
+echo "[revx-mcp] workspace=$WORKSPACE"
+
+revx_build_release
+ENGINE="$(revx_repo_root)/target/release/revx-engine"
+if [[ ! -x "$ENGINE" ]]; then
+  echo "error: missing $ENGINE" >&2
+  exit 1
+fi
+
+INSTALL_ARGS=(mcp install --prefix "$PREFIX" --workspace "$WORKSPACE" --write-config)
+if [[ "$INIT_WS" == "1" ]]; then
+  INSTALL_ARGS+=(--init-workspace)
+fi
+
+"$ENGINE" "${INSTALL_ARGS[@]}"
+INSTALLED="$PREFIX/bin/revx-engine"
+"$INSTALLED" mcp doctor --workspace "$WORKSPACE"
+
+echo
+echo "[revx-mcp] ready"
+echo "[revx-mcp] host config samples under: $PREFIX/share/revx/mcp/"
+echo "[revx-mcp] point MCP Host command to:"
+echo "  $INSTALLED mcp serve --workspace $WORKSPACE"
+echo
+echo "[revx-mcp] generic config:"
+"$INSTALLED" mcp config --host generic --workspace "$WORKSPACE" --bin "$INSTALLED"

--- a/deploy/mcp/print-config.sh
+++ b/deploy/mcp/print-config.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+HOST="${1:-generic}"
+WORKSPACE="$(revx_default_workspace)"
+if ! ENGINE="$(revx_resolve_engine)"; then
+  echo "error: revx-engine not found. Run deploy/mcp/one-click.sh first." >&2
+  exit 1
+fi
+
+"$ENGINE" mcp config --host "$HOST" --workspace "$WORKSPACE" --bin "$ENGINE"

--- a/deploy/mcp/start-mcp.sh
+++ b/deploy/mcp/start-mcp.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+WORKSPACE="$(revx_default_workspace)"
+INIT_WS="${REVX_INIT_WORKSPACE:-0}"
+
+if ! ENGINE="$(revx_resolve_engine)"; then
+  echo "[revx-mcp] engine not found; building release..." >&2
+  revx_build_release
+  ENGINE="$(revx_repo_root)/target/release/revx-engine"
+fi
+
+ARGS=(mcp serve --workspace "$WORKSPACE")
+if [[ "$INIT_WS" == "1" ]]; then
+  ARGS+=(--init)
+fi
+
+exec "$ENGINE" "${ARGS[@]}"

--- a/deploy/mcp/templates/claude_desktop.mcp.json
+++ b/deploy/mcp/templates/claude_desktop.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "revx": {
+      "command": "__REVX_ENGINE__",
+      "args": ["mcp", "serve", "--workspace", "__REVX_WORKSPACE__"]
+    }
+  }
+}

--- a/deploy/mcp/templates/codex.mcp.json
+++ b/deploy/mcp/templates/codex.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "revx": {
+      "command": "__REVX_ENGINE__",
+      "args": ["mcp", "serve", "--workspace", "__REVX_WORKSPACE__"]
+    }
+  }
+}

--- a/deploy/mcp/templates/cursor.mcp.json
+++ b/deploy/mcp/templates/cursor.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "revx": {
+      "command": "__REVX_ENGINE__",
+      "args": ["mcp", "serve", "--workspace", "__REVX_WORKSPACE__"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add deployment tooling so ReVX MCP Server can be installed and wired into Hosts with one command. CLI/engine remains the entrypoint; Codex/Cursor/Claude remain the Hosts.

## Issue
Fixes #5

https://github.com/shiaho777/revx/issues/5

## Test plan
- [x] `revx-engine mcp install --init-workspace --write-config` installs binary + host JSON samples
- [x] `mcp doctor` reports schema/workspace ok
- [x] `mcp serve --workspace` answers `initialize` + `tools/list` over stdio
- [ ] Required CI green: **ci / test**

## Notes for reviewers
- Scripts live under `deploy/mcp/` (`one-click.sh`, `start-mcp.sh`, `doctor.sh`, templates)
- `mcp serve` accepts `--workspace` / `--init` so Host configs do not rely only on cwd