### PR TITLE
Default MCP to local 127.0.0.1:9310

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,20 +115,24 @@ The high-level MCP tools are:
 
 
 
+
 ## MCP
 
 ```json
 {
   "mcpServers": {
     "revx": {
-      "url": "https://api.shiaho.sbs/mcp"
+      "url": "http://127.0.0.1:9310/mcp"
     }
   }
 }
 ```
 
-Local stdio: `revx-engine mcp serve --workspace /path/to/project`  
-HTTP: `revx-engine mcp http --bind 127.0.0.1:9310 --workspace /path/to/project`
+Run locally (uses your machine CPU/RAM):
+
+```bash
+revx-engine mcp http --bind 127.0.0.1:9310 --workspace /path/to/project
+```
 
 
 ## Build and smoke

--- a/crates/revx-engine/src/main.rs
+++ b/crates/revx-engine/src/main.rs
@@ -1510,7 +1510,7 @@ fn resolve_mcp_project_root(workspace: Option<PathBuf>, init: bool) -> Result<Pa
 }
 
 fn render_mcp_host_config(host: McpHost, engine: &Path, workspace: &Path) -> String {
-    let url = std::env::var("REVX_MCP_URL").unwrap_or_else(|_| "https://api.shiaho.sbs/mcp".to_string());
+    let url = std::env::var("REVX_MCP_URL").unwrap_or_else(|_| "http://127.0.0.1:9310/mcp".to_string());
     let engine_s = engine.display().to_string();
     let workspace_s = workspace.display().to_string();
     match host {


### PR DESCRIPTION
## Summary
Official MCP URL is local only: `http://127.0.0.1:9310/mcp`. Analysis CPU/RAM stay on the developer machine.

## Issue
Fixes #13

## Test plan
- [x] Local `GET/POST http://127.0.0.1:9310/mcp` health + tools/list
- [x] VPS `/mcp` location removed / service stopped
- [ ] CI green