### PR TITLE
One-click local MCP starters + 3-platform releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+            asset: revx-mcp-macos-arm64
+            starter: start-macos.sh
+            stopper: stop-macos.sh
+            bin: revx-engine
+          - os: macos-13
+            target: x86_64-apple-darwin
+            asset: revx-mcp-macos-x64
+            starter: start-macos.sh
+            stopper: stop-macos.sh
+            bin: revx-engine
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset: revx-mcp-linux-x64
+            starter: start-linux.sh
+            stopper: stop-linux.sh
+            bin: revx-engine
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset: revx-mcp-windows-x64
+            starter: start-windows.ps1
+            stopper: stop-windows.ps1
+            bin: revx-engine.exe
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+      - name: Install linux deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev pkg-config
+      - name: Build
+        shell: bash
+        run: cargo build -p revx-engine --release --target ${{ matrix.target }}
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="dist/${{ matrix.asset }}"
+          mkdir -p "$out"
+          bin_src="target/${{ matrix.target }}/release/${{ matrix.bin }}"
+          cp "$bin_src" "$out/${{ matrix.bin }}"
+          if [[ "${{ runner.os }}" != "Windows" ]]; then
+            chmod +x "$out/${{ matrix.bin }}"
+            cp "deploy/local/${{ matrix.starter }}" "$out/start.sh"
+            cp "deploy/local/${{ matrix.stopper }}" "$out/stop.sh"
+            chmod +x "$out/start.sh" "$out/stop.sh"
+          else
+            cp "deploy/local/start-windows.ps1" "$out/start.ps1"
+            cp "deploy/local/start-windows.cmd" "$out/start.cmd"
+            cp "deploy/local/stop-windows.ps1" "$out/stop.ps1"
+          fi
+          cat > "$out/MCP.txt" << TXT
+ReVX local MCP
+
+Start:
+  macOS/Linux: ./start.sh
+  Windows:     start.cmd   (or: powershell -File .\\start.ps1)
+
+Endpoint:
+  http://127.0.0.1:9310/mcp
+
+Codex config:
+  [mcp_servers.revx]
+  url = "http://127.0.0.1:9310/mcp"
+TXT
+          mkdir -p dist
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            powershell -NoProfile -Command "Compress-Archive -Path '$out\\*' -DestinationPath 'dist\\${{ matrix.asset }}.zip' -Force"
+          else
+            tar -C dist -czf "dist/${{ matrix.asset }}.tar.gz" "${{ matrix.asset }}"
+          fi
+          ls -la dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Flatten assets
+        run: |
+          mkdir -p release-assets
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) -exec cp {} release-assets/ \;
+          ls -la release-assets
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/*
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The high-level MCP tools are:
 
 ## MCP
 
+Local only. Analysis uses **your machine** CPU/RAM.
+
 ```json
 {
   "mcpServers": {
@@ -128,11 +130,32 @@ The high-level MCP tools are:
 }
 ```
 
-Run locally (uses your machine CPU/RAM):
+### One-click start
+
+| OS | Command |
+|----|---------|
+| macOS | `./deploy/local/start-macos.sh` |
+| Linux | `./deploy/local/start-linux.sh` |
+| Windows | `deploy/local/start-windows.cmd` |
+
+Release packages (GitHub Releases) ship the binary next to the starter:
+
+| Package | Contents |
+|---------|----------|
+| `revx-mcp-macos-arm64` | `revx-engine` + `start.sh` |
+| `revx-mcp-macos-x64` | `revx-engine` + `start.sh` |
+| `revx-mcp-linux-x64` | `revx-engine` + `start.sh` |
+| `revx-mcp-windows-x64` | `revx-engine.exe` + `start.cmd` |
 
 ```bash
-revx-engine mcp http --bind 127.0.0.1:9310 --workspace /path/to/project
+# from a release folder
+./start.sh          # macOS / Linux
+start.cmd           # Windows
 ```
+
+Stop: `./deploy/local/stop-macos.sh` / `stop-linux.sh` / `stop-windows.ps1`
+
+Publish builds: push a tag `v0.1.0` (workflow `.github/workflows/release.yml`).
 
 
 ## Build and smoke

--- a/deploy/local/start-linux.sh
+++ b/deploy/local/start-linux.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+BIND="${REVX_MCP_BIND:-127.0.0.1:9310}"
+URL="http://${BIND}/mcp"
+WORKSPACE="${REVX_WORKSPACE:-$HOME/.local/share/revx/workspace}"
+ENGINE="${REVX_ENGINE:-}"
+
+find_engine() {
+  if [[ -n "$ENGINE" && -x "$ENGINE" ]]; then echo "$ENGINE"; return; fi
+  if [[ -x "$ROOT/revx-engine" ]]; then echo "$ROOT/revx-engine"; return; fi
+  if [[ -x "$ROOT/../revx-engine" ]]; then echo "$ROOT/../revx-engine"; return; fi
+  if [[ -x "$HOME/.local/bin/revx-engine" ]]; then echo "$HOME/.local/bin/revx-engine"; return; fi
+  if command -v revx-engine >/dev/null 2>&1; then command -v revx-engine; return; fi
+  local repo
+  repo="$(cd "$ROOT/../.." 2>/dev/null && pwd || true)"
+  if [[ -n "$repo" && -f "$repo/Cargo.toml" ]]; then
+    echo "[revx] building revx-engine (release)..." >&2
+    (cd "$repo" && cargo build -p revx-engine --release) >&2
+    if [[ -x "$repo/target/release/revx-engine" ]]; then
+      echo "$repo/target/release/revx-engine"
+      return
+    fi
+  fi
+  return 1
+}
+
+if ! ENGINE_BIN="$(find_engine)"; then
+  echo "[revx] revx-engine not found. Put it next to this script or set REVX_ENGINE." >&2
+  exit 1
+fi
+
+mkdir -p "$WORKSPACE"
+if [[ ! -d "$WORKSPACE/.revx" ]]; then
+  "$ENGINE_BIN" init "$WORKSPACE" >/dev/null
+fi
+
+if curl -fsS --max-time 1 "http://${BIND}/mcp/health" >/dev/null 2>&1; then
+  echo "[revx] already running: $URL"
+  echo "[revx] engine: $ENGINE_BIN"
+  echo "[revx] workspace: $WORKSPACE"
+  exit 0
+fi
+
+echo "[revx] starting MCP HTTP"
+echo "[revx] engine: $ENGINE_BIN"
+echo "[revx] workspace: $WORKSPACE"
+echo "[revx] url: $URL"
+
+if [[ "${REVX_MCP_FOREGROUND:-0}" == "1" ]]; then
+  exec "$ENGINE_BIN" mcp http --bind "$BIND" --workspace "$WORKSPACE"
+fi
+
+nohup "$ENGINE_BIN" mcp http --bind "$BIND" --workspace "$WORKSPACE" \
+  >"$WORKSPACE/../mcp-http.log" 2>"$WORKSPACE/../mcp-http.err.log" &
+echo $! >"$WORKSPACE/../mcp-http.pid"
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -fsS --max-time 1 "http://${BIND}/mcp/health" >/dev/null 2>&1; then
+    echo "[revx] ready: $URL"
+    echo "[revx] codex config:"
+    cat <<CFG
+[mcp_servers.revx]
+url = "$URL"
+CFG
+    exit 0
+  fi
+  sleep 0.3
+done
+
+echo "[revx] started but health check failed; see $WORKSPACE/../mcp-http.err.log" >&2
+exit 1

--- a/deploy/local/start-macos.sh
+++ b/deploy/local/start-macos.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+BIND="${REVX_MCP_BIND:-127.0.0.1:9310}"
+URL="http://${BIND}/mcp"
+WORKSPACE="${REVX_WORKSPACE:-$HOME/.local/share/revx/workspace}"
+ENGINE="${REVX_ENGINE:-}"
+
+find_engine() {
+  if [[ -n "$ENGINE" && -x "$ENGINE" ]]; then echo "$ENGINE"; return; fi
+  if [[ -x "$ROOT/revx-engine" ]]; then echo "$ROOT/revx-engine"; return; fi
+  if [[ -x "$ROOT/../revx-engine" ]]; then echo "$ROOT/../revx-engine"; return; fi
+  if [[ -x "$HOME/.local/bin/revx-engine" ]]; then echo "$HOME/.local/bin/revx-engine"; return; fi
+  if command -v revx-engine >/dev/null 2>&1; then command -v revx-engine; return; fi
+  local repo
+  repo="$(cd "$ROOT/../.." 2>/dev/null && pwd || true)"
+  if [[ -n "$repo" && -f "$repo/Cargo.toml" ]]; then
+    echo "[revx] building revx-engine (release)..." >&2
+    (cd "$repo" && cargo build -p revx-engine --release) >&2
+    if [[ -x "$repo/target/release/revx-engine" ]]; then
+      echo "$repo/target/release/revx-engine"
+      return
+    fi
+  fi
+  return 1
+}
+
+if ! ENGINE_BIN="$(find_engine)"; then
+  echo "[revx] revx-engine not found. Put it next to this script or set REVX_ENGINE." >&2
+  exit 1
+fi
+
+mkdir -p "$WORKSPACE"
+if [[ ! -d "$WORKSPACE/.revx" ]]; then
+  "$ENGINE_BIN" init "$WORKSPACE" >/dev/null
+fi
+
+if curl -fsS --max-time 1 "http://${BIND}/mcp/health" >/dev/null 2>&1; then
+  echo "[revx] already running: $URL"
+  echo "[revx] engine: $ENGINE_BIN"
+  echo "[revx] workspace: $WORKSPACE"
+  exit 0
+fi
+
+echo "[revx] starting MCP HTTP"
+echo "[revx] engine: $ENGINE_BIN"
+echo "[revx] workspace: $WORKSPACE"
+echo "[revx] url: $URL"
+
+if [[ "${REVX_MCP_FOREGROUND:-0}" == "1" ]]; then
+  exec "$ENGINE_BIN" mcp http --bind "$BIND" --workspace "$WORKSPACE"
+fi
+
+nohup "$ENGINE_BIN" mcp http --bind "$BIND" --workspace "$WORKSPACE" \
+  >"$WORKSPACE/../mcp-http.log" 2>"$WORKSPACE/../mcp-http.err.log" &
+echo $! >"$WORKSPACE/../mcp-http.pid"
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -fsS --max-time 1 "http://${BIND}/mcp/health" >/dev/null 2>&1; then
+    echo "[revx] ready: $URL"
+    echo "[revx] codex config:"
+    cat <<CFG
+[mcp_servers.revx]
+url = "$URL"
+CFG
+    exit 0
+  fi
+  sleep 0.3
+done
+
+echo "[revx] started but health check failed; see $WORKSPACE/../mcp-http.err.log" >&2
+exit 1

--- a/deploy/local/start-windows.cmd
+++ b/deploy/local/start-windows.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0start-windows.ps1" %*
+exit /b %ERRORLEVEL%

--- a/deploy/local/start-windows.ps1
+++ b/deploy/local/start-windows.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = "Stop"
+
+$Root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Bind = if ($env:REVX_MCP_BIND) { $env:REVX_MCP_BIND } else { "127.0.0.1:9310" }
+$Url = "http://$Bind/mcp"
+$Workspace = if ($env:REVX_WORKSPACE) { $env:REVX_WORKSPACE } else { Join-Path $env:LOCALAPPDATA "revx\workspace" }
+
+function Find-Engine {
+  if ($env:REVX_ENGINE -and (Test-Path $env:REVX_ENGINE)) { return $env:REVX_ENGINE }
+  $candidates = @(
+    (Join-Path $Root "revx-engine.exe"),
+    (Join-Path $Root "revx-engine"),
+    (Join-Path (Split-Path $Root -Parent) "revx-engine.exe")
+  )
+  foreach ($c in $candidates) {
+    if (Test-Path $c) { return $c }
+  }
+  $cmd = Get-Command revx-engine.exe -ErrorAction SilentlyContinue
+  if ($cmd) { return $cmd.Source }
+  $cmd = Get-Command revx-engine -ErrorAction SilentlyContinue
+  if ($cmd) { return $cmd.Source }
+  return $null
+}
+
+$Engine = Find-Engine
+if (-not $Engine) {
+  Write-Error "[revx] revx-engine not found. Place revx-engine.exe next to this script or set REVX_ENGINE."
+}
+
+New-Item -ItemType Directory -Force -Path $Workspace | Out-Null
+if (-not (Test-Path (Join-Path $Workspace ".revx"))) {
+  & $Engine init $Workspace | Out-Null
+}
+
+try {
+  $health = Invoke-WebRequest -Uri "http://$Bind/mcp/health" -UseBasicParsing -TimeoutSec 1
+  if ($health.StatusCode -eq 200) {
+    Write-Host "[revx] already running: $Url"
+    Write-Host "[revx] engine: $Engine"
+    Write-Host "[revx] workspace: $Workspace"
+    exit 0
+  }
+} catch {}
+
+Write-Host "[revx] starting MCP HTTP"
+Write-Host "[revx] engine: $Engine"
+Write-Host "[revx] workspace: $Workspace"
+Write-Host "[revx] url: $Url"
+
+$logDir = Split-Path $Workspace -Parent
+$outLog = Join-Path $logDir "mcp-http.log"
+$errLog = Join-Path $logDir "mcp-http.err.log"
+
+if ($env:REVX_MCP_FOREGROUND -eq "1") {
+  & $Engine mcp http --bind $Bind --workspace $Workspace
+  exit $LASTEXITCODE
+}
+
+$proc = Start-Process -FilePath $Engine -ArgumentList @("mcp","http","--bind",$Bind,"--workspace",$Workspace) `
+  -WindowStyle Hidden -PassThru -RedirectStandardOutput $outLog -RedirectStandardError $errLog
+$proc.Id | Out-File -Encoding ascii (Join-Path $logDir "mcp-http.pid")
+
+for ($i = 0; $i -lt 20; $i++) {
+  try {
+    $health = Invoke-WebRequest -Uri "http://$Bind/mcp/health" -UseBasicParsing -TimeoutSec 1
+    if ($health.StatusCode -eq 200) {
+      Write-Host "[revx] ready: $Url"
+      Write-Host "[revx] codex config:"
+      Write-Host "[mcp_servers.revx]"
+      Write-Host "url = `"$Url`""
+      exit 0
+    }
+  } catch {}
+  Start-Sleep -Milliseconds 300
+}
+
+Write-Error "[revx] started but health check failed; see $errLog"

--- a/deploy/local/stop-linux.sh
+++ b/deploy/local/stop-linux.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BIND="${REVX_MCP_BIND:-127.0.0.1:9310}"
+PID_FILE="${REVX_WORKSPACE:-$HOME/.local/share/revx/workspace}/../mcp-http.pid"
+if [[ -f "$PID_FILE" ]]; then
+  kill "$(cat "$PID_FILE")" 2>/dev/null || true
+  rm -f "$PID_FILE"
+fi
+if command -v fuser >/dev/null 2>&1; then
+  fuser -k "${BIND##*:}/tcp" 2>/dev/null || true
+elif command -v lsof >/dev/null 2>&1; then
+  PIDS="$(lsof -tiTCP:${BIND##*:} -sTCP:LISTEN 2>/dev/null || true)"
+  if [[ -n "${PIDS:-}" ]]; then kill $PIDS 2>/dev/null || true; fi
+fi
+echo "[revx] stopped ${BIND}"

--- a/deploy/local/stop-macos.sh
+++ b/deploy/local/stop-macos.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BIND="${REVX_MCP_BIND:-127.0.0.1:9310}"
+PID_FILE="${REVX_WORKSPACE:-$HOME/.local/share/revx/workspace}/../mcp-http.pid"
+if [[ -f "$PID_FILE" ]]; then
+  kill "$(cat "$PID_FILE")" 2>/dev/null || true
+  rm -f "$PID_FILE"
+fi
+if command -v lsof >/dev/null 2>&1; then
+  PIDS="$(lsof -tiTCP:${BIND##*:} -sTCP:LISTEN 2>/dev/null || true)"
+  if [[ -n "${PIDS:-}" ]]; then kill $PIDS 2>/dev/null || true; fi
+fi
+echo "[revx] stopped ${BIND}"

--- a/deploy/local/stop-windows.ps1
+++ b/deploy/local/stop-windows.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = "SilentlyContinue"
+$Bind = if ($env:REVX_MCP_BIND) { $env:REVX_MCP_BIND } else { "127.0.0.1:9310" }
+$Port = [int]($Bind.Split(":")[-1])
+$Workspace = if ($env:REVX_WORKSPACE) { $env:REVX_WORKSPACE } else { Join-Path $env:LOCALAPPDATA "revx\workspace" }
+$PidFile = Join-Path (Split-Path $Workspace -Parent) "mcp-http.pid"
+if (Test-Path $PidFile) {
+  $procId = Get-Content $PidFile | Select-Object -First 1
+  if ($procId) { Stop-Process -Id $procId -Force }
+  Remove-Item $PidFile -Force
+}
+Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue |
+  ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+Write-Host "[revx] stopped $Bind"


### PR DESCRIPTION
## Summary
Add one-click local MCP HTTP starters for Windows, macOS, and Linux, plus a GitHub Release workflow that ships three separate platform packages with binary + start script.

## Issue
Fixes #15

## Test plan
- [x] `./deploy/local/start-macos.sh` reports ready / already running at `http://127.0.0.1:9310/mcp`
- [x] README documents starters + release package names
- [ ] CI green
- [ ] Tag `v*` later to exercise release workflow

## Packages
- `revx-mcp-macos-arm64`
- `revx-mcp-macos-x64`
- `revx-mcp-linux-x64`
- `revx-mcp-windows-x64`