### PR TITLE
ci: build macOS x64 package on macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
             starter: start-macos.sh
             stopper: stop-macos.sh
             bin: revx-engine
-          - os: macos-13
+          - os: macos-14
             target: x86_64-apple-darwin
             asset: revx-mcp-macos-x64
             starter: start-macos.sh


### PR DESCRIPTION
## Summary
- Switch release matrix for `revx-mcp-macos-x64` from `macos-13` to `macos-14` (`x86_64-apple-darwin` target)
- Unblocks GitHub Releases when Intel mac runners stay queued

## Fixes
Fixes #21

## Test plan
- [ ] CI green
- [ ] After merge, tag `v0.1.2` and confirm all four matrix jobs + publish succeed