### PR TITLE
正确性修复：arm64 真实指令字节 / daemon stop 杀进程 / micro x64 / panic 传播

### DIFF
--- a/crates/revx-analysis/src/lib.rs
+++ b/crates/revx-analysis/src/lib.rs
@@ -303,8 +303,6 @@ impl CodeRegion {
     }
 }
 
-fn release_code_region_pages(_code_regions: &[CodeRegion]) {}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct StringRange {
     start: u64,
@@ -634,19 +632,42 @@ pub fn analyze_parallel(images: Vec<BinaryImage>, profile: AnalysisProfile) -> V
         handles.push(thread::spawn(move || {
             chunk
                 .into_iter()
-                .map(|img| analyze(img, profile))
+                .map(|img| std::panic::catch_unwind(|| analyze(img, profile)))
                 .collect::<Vec<_>>()
         }));
     }
 
     let mut results = Vec::new();
+    let mut panics: Vec<String> = Vec::new();
     for handle in handles {
         match handle.join() {
-            Ok(bundles) => results.extend(bundles),
-            Err(_) => {} // Panic in worker thread — skip and continue
+            Ok(outcomes) => {
+                for outcome in outcomes {
+                    match outcome {
+                        Ok(bundle) => results.push(bundle),
+                        Err(payload) => panics.push(panic_message(payload)),
+                    }
+                }
+            }
+            Err(payload) => panics.push(panic_message(payload)),
         }
     }
+    if !panics.is_empty() {
+        eprintln!(
+            "revx: analyze_parallel recovered {} worker panic(s): {:?}",
+            panics.len(),
+            panics
+        );
+    }
     results
+}
+
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    payload
+        .downcast_ref::<String>()
+        .map(|s| s.to_string())
+        .or_else(|| payload.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_else(|| "<non-string panic>".to_string())
 }
 
 pub fn survey(image: BinaryImage, profile: AnalysisProfile) -> Survey {
@@ -1915,7 +1936,6 @@ where
                 )
             });
         }
-        release_code_region_pages(&code_regions);
     }
     revx_trace(|| {
         format!(
@@ -9331,14 +9351,7 @@ fn format_stack_location(start_offset: i64, end_offset: Option<i64>) -> String {
 
 #[inline]
 fn inst_len(inst: &Instruction) -> usize {
-    let n = inst.bytes.len();
-    if n == 8 {
-        4
-    } else if n == 2 {
-        1
-    } else {
-        n / 2
-    }
+    inst.bytes.len() / 2
 }
 
 fn sanitize_symbol(name: &str) -> String {

--- a/crates/revx-arch-arm64/src/lib.rs
+++ b/crates/revx-arch-arm64/src/lib.rs
@@ -1,7 +1,5 @@
 mod format_fast;
-use revx_core::{
-    Instruction, Reference, ReferenceKind, arm64_len_marker, intern_str_local, static_str,
-};
+use revx_core::{Instruction, Reference, ReferenceKind, intern_hex, intern_str_local, static_str};
 use std::collections::HashSet;
 use yaxpeax_arch::{Arch, Decoder as YaxDecoder, LengthedInstruction, U8Reader};
 use yaxpeax_arm::armv8::a64::{ARMv8, Opcode, Operand};
@@ -80,10 +78,9 @@ fn decode_inner_with_references(
                         }
                     }
                 };
-                let _ = inst_bytes;
                 instructions.push(Instruction {
                     address,
-                    bytes: arm64_len_marker(),
+                    bytes: intern_hex(inst_bytes),
                     text: text_arc,
                 });
 

--- a/crates/revx-core/src/intern.rs
+++ b/crates/revx-core/src/intern.rs
@@ -102,11 +102,6 @@ pub fn intern_str_local(value: &str) -> Arc<str> {
     })
 }
 
-pub fn arm64_len_marker() -> Arc<str> {
-    static MARKER: OnceLock<Arc<str>> = OnceLock::new();
-    Arc::clone(MARKER.get_or_init(|| Arc::from("........")))
-}
-
 pub fn static_str(value: &'static str) -> Arc<str> {
     thread_local! {
         static CACHE: RefCell<HashMap<&'static str, Arc<str>>> =

--- a/crates/revx-daemon/src/lib.rs
+++ b/crates/revx-daemon/src/lib.rs
@@ -1715,6 +1715,7 @@ impl CapabilityService {
 pub async fn serve_ipc(workspace_root: PathBuf) -> Result<()> {
     let _ = revx_analysis::resource::ensure_process_resource_limits();
     let endpoint = socket_path(&workspace_root);
+    write_daemon_pid(&workspace_root);
     #[cfg(unix)]
     {
         if endpoint.exists() {
@@ -1791,6 +1792,71 @@ pub fn socket_path(workspace_root: &Path) -> PathBuf {
     {
         workspace_root.join(".revx").join("daemon.tcp")
     }
+}
+
+pub fn pid_path(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".revx").join("daemon.pid")
+}
+
+pub fn write_daemon_pid(workspace_root: &Path) {
+    let pid = std::process::id();
+    let _ = std::fs::write(pid_path(workspace_root), pid.to_string());
+}
+
+pub fn stop_daemon(workspace_root: &Path) -> Result<()> {
+    let endpoint = socket_path(workspace_root);
+    let pid_file = pid_path(workspace_root);
+    let pid_text = std::fs::read_to_string(&pid_file).ok();
+    if let Some(raw) = pid_text.as_deref()
+        && let Ok(pid) = raw.trim().parse::<u32>()
+    {
+        #[cfg(unix)]
+        {
+            use std::io;
+            if signal_process(pid, libc_signal_term()) {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+                while endpoint.exists() && std::time::Instant::now() < deadline {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                if endpoint.exists() {
+                    let _ = signal_process(pid, libc_signal_kill());
+                }
+            }
+            let _ = io::Result::<()>::Ok(());
+        }
+        #[cfg(windows)]
+        {
+            let _ = std::process::Command::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/F"])
+                .output();
+        }
+        println!("Stopped daemon pid {pid}");
+    }
+    if endpoint.exists() {
+        std::fs::remove_file(&endpoint)
+            .with_context(|| format!("failed to remove {}", endpoint.display()))?;
+        println!("Removed daemon socket {}", endpoint.display());
+    }
+    let _ = std::fs::remove_file(&pid_file);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn signal_process(pid: u32, signal: i32) -> bool {
+    unsafe extern "C" {
+        fn kill(pid: i32, sig: i32) -> i32;
+    }
+    unsafe { kill(pid as i32, signal) == 0 }
+}
+
+#[cfg(unix)]
+fn libc_signal_term() -> i32 {
+    15
+}
+
+#[cfg(unix)]
+fn libc_signal_kill() -> i32 {
+    9
 }
 
 pub fn windows_pipe_name(workspace_root: &Path) -> String {

--- a/crates/revx-engine/src/main.rs
+++ b/crates/revx-engine/src/main.rs
@@ -1254,12 +1254,17 @@ async fn cmd_daemon_start() -> Result<()> {
 fn cmd_daemon_status() -> Result<()> {
     let workspace_dir = workspace_parent_from_cwd()?;
     let socket = socket_path(&workspace_dir);
+    let pid_file = revx_daemon::pid_path(&workspace_dir);
+    let pid = std::fs::read_to_string(&pid_file)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u32>().ok());
     println!(
         "{}",
         serde_json::json!({
             "workspace_root": workspace_dir.display().to_string(),
             "ipc_path": socket.display().to_string(),
             "available": socket.exists(),
+            "pid": pid,
         })
     );
     Ok(())
@@ -1268,14 +1273,11 @@ fn cmd_daemon_status() -> Result<()> {
 fn cmd_daemon_stop() -> Result<()> {
     let workspace_dir = workspace_parent_from_cwd()?;
     let socket = socket_path(&workspace_dir);
-    if socket.exists() {
-        fs::remove_file(&socket)
-            .with_context(|| format!("failed to remove {}", socket.display()))?;
-        println!("Removed daemon socket {}", socket.display());
-    } else {
-        println!("No daemon socket present at {}", socket.display());
+    if !socket.exists() && !revx_daemon::pid_path(&workspace_dir).exists() {
+        println!("No daemon present at {}", socket.display());
+        return Ok(());
     }
-    Ok(())
+    revx_daemon::stop_daemon(&workspace_dir)
 }
 
 async fn cmd_mcp_serve(workspace: Option<PathBuf>, init: bool) -> Result<()> {

--- a/crates/revx-micro/src/main.rs
+++ b/crates/revx-micro/src/main.rs
@@ -158,14 +158,21 @@ fn analyze(path: &Path) -> Result<(), String> {
         };
         let insts = if arch == "arm64" {
             count_arm64_insts(&window)
+        } else if arch == "x86_64" {
+            count_x64_insts(&window)
         } else {
             0
+        };
+        let inst_size = if arch == "arm64" {
+            insts.saturating_mul(4)
+        } else {
+            window.len()
         };
         functions.push(format!(
             "{{\"name\":{},\"address\":{},\"size\":{},\"insts\":{}}}",
             json_str(&name),
             addr,
-            insts.saturating_mul(4),
+            inst_size,
             insts
         ));
     }
@@ -245,6 +252,275 @@ fn is_arm64_terminal(w: u32) -> bool {
         return true;
     }
     false
+}
+
+const X64_ONE_BYTE: [bool; 256] = x64_one_byte_table();
+const X64_PREFIXES: [bool; 256] = x64_prefix_table();
+
+const fn x64_prefix_table() -> [bool; 256] {
+    let mut t = [false; 256];
+    let mut i = 0;
+    while i < 256 {
+        t[i] = matches!(
+            i,
+            0xF0 | 0xF2 | 0xF3 | 0x2E | 0x36 | 0x3E | 0x26 | 0x64 | 0x65 | 0x66 | 0x67
+        );
+        i += 1;
+    }
+    t
+}
+
+const fn x64_one_byte_table() -> [bool; 256] {
+    let mut t = [false; 256];
+    let one_byte: &[u8] = &[
+        0x06, 0x07, 0x0E, 0x16, 0x17, 0x1E, 0x1F, 0x27, 0x2F, 0x37, 0x3F, 0x40, 0x41, 0x42, 0x43,
+        0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52,
+        0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61,
+        0x62, 0x63, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x90, 0x9B, 0x9C, 0x9D, 0x9E,
+        0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF, 0xC3, 0xC9, 0xCB,
+        0xF5, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE,
+    ];
+    let mut i = 0;
+    while i < one_byte.len() {
+        t[one_byte[i] as usize] = true;
+        i += 1;
+    }
+    t
+}
+
+const X64_MODRM_RM_ONLY: [bool; 8] = [true, true, true, false, true, false, false, false];
+
+#[allow(
+    clippy::if_same_then_else,
+    clippy::manual_range_contains,
+    clippy::match_like_matches_macro
+)]
+fn count_x64_insts(bytes: &[u8]) -> usize {
+    let mut n = 0usize;
+    let mut off = 0usize;
+    while off < bytes.len() && n < MAX_INSTS {
+        let start = off;
+        let mut p = off;
+        while p < bytes.len() && X64_PREFIXES[bytes[p] as usize] {
+            p += 1;
+        }
+        if p >= bytes.len() {
+            break;
+        }
+        let opcode = bytes[p] as usize;
+        p += 1;
+
+        if opcode == 0x0F {
+            if p >= bytes.len() {
+                break;
+            }
+            let second = bytes[p] as usize;
+            p += 1;
+            p += x64_modrm_len_after_0f(second, bytes, p);
+            if (0x80..=0x8F).contains(&second) {
+                p += 4;
+            }
+        } else if X64_ONE_BYTE[opcode] {
+            if (0x40..=0x4F).contains(&opcode) {
+                if p < bytes.len() {
+                    p += 1;
+                }
+            } else if opcode == 0x68 {
+                p += 4;
+            } else if matches!(opcode, 0x6A | 0xA8 | 0xA9) {
+                p += 1;
+            } else if (0x50..=0x5F).contains(&opcode)
+                || matches!(
+                    opcode,
+                    0x90 | 0x9C | 0x9D | 0x9E | 0x9B | 0xC3 | 0xC9 | 0xCB
+                )
+            {
+            } else if matches!(opcode, 0x69 | 0x6B) {
+                p += 1 + x64_modrm_len(bytes, p);
+                p += 4;
+            } else if matches!(
+                opcode,
+                0x6C | 0x6D
+                    | 0x6E
+                    | 0x6F
+                    | 0xA4
+                    | 0xA5
+                    | 0xA6
+                    | 0xA7
+                    | 0xAA
+                    | 0xAB
+                    | 0xAC
+                    | 0xAD
+                    | 0xAE
+                    | 0xAF
+            ) {
+            }
+        } else if (0x00..=0x3F).contains(&opcode) {
+            let group = opcode >> 3;
+            p += x64_modrm_len(bytes, p);
+            if group == 0x1 && (opcode & 1) == 0 {
+                p += 1;
+            } else if group == 0x1 && (opcode & 1) == 1 {
+                p += 4;
+            }
+        } else if (0x70..=0x7F).contains(&opcode) {
+            p += 1;
+        } else if (0x80..=0x83).contains(&opcode) {
+            let imm = if opcode == 0x83 { 1 } else { 4 };
+            p += x64_modrm_len(bytes, p);
+            p += imm;
+        } else if (0x84..=0x8F).contains(&opcode) {
+            p += x64_modrm_len(bytes, p);
+        } else if (0xB0..=0xB7).contains(&opcode) {
+            p += 1;
+        } else if (0xB8..=0xBF).contains(&opcode) {
+            p += 8;
+        } else if (0xC0..=0xC1).contains(&opcode) {
+            p += x64_modrm_len(bytes, p);
+            p += 1;
+        } else if (0xC2..=0xC3).contains(&opcode) {
+            if opcode == 0xC2 {
+                p += 2;
+            }
+        } else if matches!(opcode, 0xC6) {
+            p += x64_modrm_len(bytes, p);
+            p += 4;
+        } else if matches!(opcode, 0xC7) {
+            p += x64_modrm_len(bytes, p);
+            p += 1;
+        } else if (0xC8..=0xCF).contains(&opcode) {
+            if matches!(opcode, 0xC8) {
+                p += 4;
+            }
+        } else if (0xD0..=0xD3).contains(&opcode) {
+            p += x64_modrm_len(bytes, p);
+        } else if (0xD8..=0xDF).contains(&opcode) {
+            p += x64_modrm_len(bytes, p);
+        } else if (0xE0..=0xE2).contains(&opcode) {
+            p += 1;
+        } else if matches!(opcode, 0xE3) {
+            p += 1;
+        } else if (0xE4..=0xE7).contains(&opcode) {
+            p += 1;
+        } else if matches!(opcode, 0xE8 | 0xE9) {
+            p += 4;
+        } else if matches!(opcode, 0xEA) {
+            p += 6;
+        } else if matches!(opcode, 0xEB) {
+            p += 1;
+        } else if (0xEC..=0xEF).contains(&opcode) {
+        } else if (0xF1..=0xF7).contains(&opcode) {
+            p += x64_modrm_len(bytes, p);
+        }
+
+        let consumed = p.saturating_sub(start).max(1).min(bytes.len() - start);
+        off += consumed;
+        n += 1;
+        if x64_is_terminal(bytes, start, consumed) {
+            break;
+        }
+    }
+    n
+}
+
+fn x64_modrm_len(bytes: &[u8], p: usize) -> usize {
+    if p >= bytes.len() {
+        return 0;
+    }
+    let modrm = bytes[p];
+    let mode = (modrm >> 6) & 0x3;
+    let rm = (modrm & 0x7) as usize;
+    match mode {
+        0x3 => 1,
+        0x0 => {
+            if X64_MODRM_RM_ONLY[rm] {
+                1
+            } else if rm == 4 {
+                1 + x64_sib_len(bytes, p + 1)
+            } else {
+                1
+            }
+        }
+        0x1 => {
+            let base = if rm == 4 {
+                1 + x64_sib_len(bytes, p + 1)
+            } else {
+                1
+            };
+            base + 1
+        }
+        0x2 => {
+            let base = if rm == 4 {
+                1 + x64_sib_len(bytes, p + 1)
+            } else {
+                1
+            };
+            base + 4
+        }
+        _ => 1,
+    }
+}
+
+fn x64_sib_len(bytes: &[u8], p: usize) -> usize {
+    if p >= bytes.len() {
+        return 0;
+    }
+    let sib = bytes[p];
+    let base = (sib & 0x7) as usize;
+    if base == 5 { 4 } else { 0 }
+}
+
+fn x64_modrm_len_after_0f(second: usize, bytes: &[u8], p: usize) -> usize {
+    let needs_modrm = (0x00..=0x03).contains(&second)
+        || (0x10..=0x17).contains(&second)
+        || (0x20..=0x23).contains(&second)
+        || (0x28..=0x2F).contains(&second)
+        || (0x40..=0x4F).contains(&second)
+        || (0x51..=0x5F).contains(&second)
+        || (0x60..=0x6F).contains(&second)
+        || (0x70..=0x73).contains(&second)
+        || (0x90..=0x9F).contains(&second)
+        || (0xA3..=0xA7).contains(&second)
+        || (0xAF..=0xB7).contains(&second)
+        || (0xB9..=0xBF).contains(&second)
+        || (0xC0..=0xC1).contains(&second)
+        || (0xC4..=0xC5).contains(&second)
+        || (0xC8..=0xCF).contains(&second)
+        || (0xD1..=0xD7).contains(&second)
+        || (0xDB..=0xDF).contains(&second)
+        || (0xE0..=0xE7).contains(&second)
+        || (0xF0..=0xF7).contains(&second);
+    if needs_modrm {
+        x64_modrm_len(bytes, p)
+    } else {
+        0
+    }
+}
+
+fn x64_is_terminal(bytes: &[u8], start: usize, len: usize) -> bool {
+    if len == 0 {
+        return false;
+    }
+    let op = bytes[start];
+    let mut p = start + 1;
+    while p < start + len && X64_PREFIXES[bytes[p] as usize] {
+        p += 1;
+    }
+    if p >= start + len {
+        return false;
+    }
+    let code = bytes[p];
+    code == 0xC3
+        || code == 0xC2
+        || code == 0xCB
+        || code == 0xCA
+        || (code == 0x0F && p + 1 < start + len && bytes[p + 1] >= 0x80 && bytes[p + 1] <= 0x8F)
+        || (code == 0xE9)
+        || (code == 0xEA)
+        || (code == 0xEB)
+        || (code == 0xFF && p + 1 < start + len && (bytes[p + 1] >> 3) & 0x7 == 4)
+        || (code == 0xFF && p + 1 < start + len && (bytes[p + 1] >> 3) & 0x7 == 5)
+        || (op == 0xC3)
 }
 
 fn json_str(s: &str) -> String {


### PR DESCRIPTION
## What & Why

修复一批长期存在的正确性缺陷（此前 CI 从不跑这些路径，M1 才让它们可见）。

## Changes

1. **arm64 真实指令字节**：decode 循环已解码出 `inst_bytes` 但被 `let _ = inst_bytes` 丢弃，存的是占位符 `"........"`。改为 `intern_hex(inst_bytes)` 存真实字节 → arch 级 `extract_references` 从真实字节重解码生效；`inst_len` 简化为 `bytes.len()/2`；删除 `arm64_len_marker`。
2. **daemon stop 杀进程**：`serve_ipc` 启动时写 `.revx/daemon.pid`；`stop_daemon` 读 pid → SIGTERM → 等 5s socket 清理 → 兜底 SIGKILL（Windows 用 taskkill），再清理 socket+pid；`status` 报告 pid。此前 `stop` 只删 socket 文件、进程继续跑。
3. **revx-micro x64 支持**：纯 std 手写 x86-64 指令长度解码器（表驱动 + ModRM/SIB 解析），x64 二进制不再恒报 insts:0。
4. **analyze_parallel panic 传播**：worker 用 `catch_unwind` 捕获 panic，收集信息后 eprintln 报告，不再静默丢结果。
5. 删除死代码 `release_code_region_pages` 空实现 + 调用点。

## Verification
- `cargo test --workspace --all-targets`：**233 passed / 0 failed / 6 ignored**
- `cargo clippy --workspace --all-targets -- -D warnings`：0 errors
- `cargo fmt --all -- --check`：clean
- arm64 改动无回归（parity 矩阵 arm64 case 全过；function recovery 用 decode-time 引用提取，函数数不变）

Fixes #27