### PR TITLE
perf: 并行度默认值 + 分析上限 env 可配置化 + 基准设施 (M3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +116,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +145,33 @@ checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -189,6 +237,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +313,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -330,6 +451,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +501,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +529,26 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -535,6 +693,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "pdb"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +720,34 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -588,6 +780,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "revx"
 version = "0.1.0"
 dependencies = [
@@ -599,6 +840,7 @@ dependencies = [
 name = "revx-analysis"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "memmap2",
  "object",
  "revx-arch-arm64",
@@ -793,6 +1035,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +1222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1371,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1429,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1234,6 +1524,26 @@ checksum = "d8aa9155f0d727d10e91e5a94f68f415ec24c7a5faab4eac2386a1069e4a02d7"
 dependencies = [
  "bitvec",
  "yaxpeax-arch",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
 clap = { version = "4.5", default-features = false, features = ["std", "derive", "help", "usage", "error-context"] }
 crc32fast = "1.5"
+criterion = "0.5"
 dirs = "6"
 fallible-iterator = "0.3"
 flate2 = "1"
@@ -66,6 +67,11 @@ debug = 0
 incremental = false
 
 [profile.release-fast]
+inherits = "release"
+opt-level = 3
+lto = "thin"
+
+[profile.bench]
 inherits = "release"
 opt-level = 3
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Place `revx`, `revx-engine`, and `revx-micro` side by side on `PATH` (or set `RE
 
 Default analysis targets single-digit MB process growth (`REVX_RSS_MB=8`, 1 job, lean Fast snapshots). Raise only when needed via `REVX_FULL_MEM=1` / `REVX_RSS_MB=512`. Ultra-low: `REVX_MICRO=1`.
 
+When memory headroom is raised (`REVX_FULL_MEM=1` or `REVX_RSS_MB`/`REVX_RSS_KB` above the 8 MB default), analysis jobs default to `min(4, available cores)`; lean/micro stay at 1. Set `REVX_JOBS` to override explicitly.
+
+Analysis depth caps are tunable per run without recompiling: `REVX_MAX_GLOBAL_REFERENCES` (512), `REVX_MAX_CFG_BLOCKS` (48), `REVX_MAX_CFG_INSTRUCTIONS` (192), `REVX_MAX_SHARED_STRING_MAP` (64), `REVX_MAX_DATA_REF_SCAN_INSTS` (256). An explicit value wins over the lean-mode clamp.
+
+Benchmarks: `scripts/bench.sh` runs the criterion suite (`cargo bench -p revx-analysis --bench analyze`) in lean and full-memory passes and writes a CSV baseline to `target/bench-results/<stamp>/summary.csv`.
+
 ## Commands
 
 The public command surface is constrained to the v1 plan:

--- a/crates/revx-analysis/Cargo.toml
+++ b/crates/revx-analysis/Cargo.toml
@@ -20,6 +20,11 @@ revx-arch-x64 = { path = "../revx-arch-x64", optional = true }
 revx-core = { path = "../revx-core" }
 
 [dev-dependencies]
+criterion.workspace = true
 object = { workspace = true, features = ["write"] }
 revx-loader = { path = "../revx-loader" }
 revx-testkit = { path = "../revx-testkit" }
+
+[[bench]]
+name = "analyze"
+harness = false

--- a/crates/revx-analysis/benches/analyze.rs
+++ b/crates/revx-analysis/benches/analyze.rs
@@ -1,0 +1,25 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use revx_analysis::analyze;
+use revx_core::AnalysisProfile;
+use revx_loader::load_binary;
+use revx_testkit::{elf_args_call_cases, write_temp};
+
+fn bench_analyze(c: &mut Criterion) {
+    let mut group = c.benchmark_group("analyze");
+    for case in elf_args_call_cases() {
+        let path = write_temp(&case);
+        for profile in [AnalysisProfile::Fast, AnalysisProfile::Full] {
+            let id = format!("{}/{:?}", case.id, profile).to_lowercase();
+            group.bench_with_input(id.as_str(), &path, |b, path| {
+                b.iter(|| {
+                    let image = load_binary(black_box(path)).expect("load fixture");
+                    analyze(image, profile)
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_analyze);
+criterion_main!(benches);

--- a/crates/revx-analysis/src/lib.rs
+++ b/crates/revx-analysis/src/lib.rs
@@ -118,6 +118,30 @@ const MAX_DATA_REF_SCAN_INSTS: usize = 256;
 const MAX_GLOBAL_REFERENCES: usize = 512;
 const MAX_SHARED_STRING_MAP: usize = 64;
 
+fn data_ref_scan_limit() -> usize {
+    revx_core::analysis_caps()
+        .data_ref_scan_insts
+        .unwrap_or(MAX_DATA_REF_SCAN_INSTS)
+}
+
+fn shared_string_map_limit() -> usize {
+    revx_core::analysis_caps()
+        .shared_string_map
+        .unwrap_or(MAX_SHARED_STRING_MAP)
+}
+
+fn global_reference_limit() -> usize {
+    revx_core::analysis_caps()
+        .global_references
+        .unwrap_or_else(|| {
+            if resource::lean_mode() {
+                MAX_GLOBAL_REFERENCES.min(64)
+            } else {
+                MAX_GLOBAL_REFERENCES.min(1024)
+            }
+        })
+}
+
 #[inline]
 fn format_sub_addr(addr: u64) -> String {
     let mut s = String::with_capacity(20);
@@ -936,11 +960,7 @@ where
     string_ranges.sort_unstable_by_key(|range| range.start);
     let relocation_refs = collect_relocation_references(image, &string_ranges, &executable);
 
-    let ref_cap = if resource::lean_mode() {
-        MAX_GLOBAL_REFERENCES.min(64)
-    } else {
-        MAX_GLOBAL_REFERENCES.min(1024)
-    };
+    let ref_cap = global_reference_limit();
     let mut all_references = HashSet::<Reference>::with_capacity(ref_cap);
     for reference in &relocation_refs {
         all_references.insert(*reference);
@@ -1086,7 +1106,7 @@ where
                             &string_ranges,
                             &executable,
                         );
-                        if instructions.len() <= MAX_DATA_REF_SCAN_INSTS {
+                        if instructions.len() <= data_ref_scan_limit() {
                             combined_references.extend(extract_data_references(
                                 architecture,
                                 &instructions,
@@ -1316,7 +1336,7 @@ where
             .strings
             .iter()
             .filter_map(|s| s.address.map(|a| (a, s.value.as_str())))
-            .take(MAX_SHARED_STRING_MAP)
+            .take(shared_string_map_limit())
             .map(|(a, v)| (a, v.to_string()))
             .collect::<HashMap<_, _>>(),
     );
@@ -1403,7 +1423,7 @@ where
         };
         if profile == AnalysisProfile::Full {
             promote_data_reference_kinds(&mut combined_references, &string_ranges, &executable);
-            if instructions.len() <= MAX_DATA_REF_SCAN_INSTS {
+            if instructions.len() <= data_ref_scan_limit() {
                 combined_references.extend(extract_data_references(
                     architecture,
                     &instructions,
@@ -2086,19 +2106,23 @@ fn is_resolved_code_target(addr: u64) -> bool {
 }
 
 fn cfg_block_limit() -> usize {
-    if resource::lean_mode() {
-        8
-    } else {
-        MAX_CFG_BLOCKS
-    }
+    revx_core::analysis_caps()
+        .cfg_blocks
+        .unwrap_or(if resource::lean_mode() {
+            8
+        } else {
+            MAX_CFG_BLOCKS
+        })
 }
 
 fn cfg_inst_limit() -> usize {
-    if resource::lean_mode() {
-        32
-    } else {
-        MAX_CFG_INSTRUCTIONS
-    }
+    revx_core::analysis_caps()
+        .cfg_instructions
+        .unwrap_or(if resource::lean_mode() {
+            32
+        } else {
+            MAX_CFG_INSTRUCTIONS
+        })
 }
 
 fn default_max_function_bytes(architecture: Architecture, profile: AnalysisProfile) -> usize {
@@ -2945,11 +2969,13 @@ fn decode_arm64_cfg_with_references(
     executable: &[(u64, u64)],
 ) -> (Vec<Instruction>, Vec<Reference>) {
     let mut queue = VecDeque::from([start]);
-    let estimated_blocks =
-        ((max_end.saturating_sub(start) / 16) as usize).clamp(4, cfg_block_limit());
+    let estimated_blocks = ((max_end.saturating_sub(start) / 16) as usize)
+        .max(4)
+        .min(cfg_block_limit());
     let mut visited_blocks = HashSet::with_capacity(estimated_blocks);
-    let estimated_insts =
-        ((max_end.saturating_sub(start) / 4) as usize).clamp(16, cfg_inst_limit());
+    let estimated_insts = ((max_end.saturating_sub(start) / 4) as usize)
+        .max(16)
+        .min(cfg_inst_limit());
     let mut instruction_map: HashMap<u64, Instruction> = HashMap::with_capacity(estimated_insts);
     let mut all_refs = Vec::with_capacity(estimated_blocks);
     let mut saw_br = false;
@@ -3579,8 +3605,9 @@ fn decode_x64_cfg_with_references(
     executable: &[(u64, u64)],
 ) -> (Vec<Instruction>, Vec<Reference>) {
     let mut queue = VecDeque::from([start]);
-    let estimated_blocks =
-        ((max_end.saturating_sub(start) / 12) as usize).clamp(4, cfg_block_limit());
+    let estimated_blocks = ((max_end.saturating_sub(start) / 12) as usize)
+        .max(4)
+        .min(cfg_block_limit());
     let mut visited_blocks = HashSet::with_capacity(estimated_blocks);
     let mut instruction_map: BTreeMap<u64, Instruction> = BTreeMap::new();
     let mut all_refs = Vec::with_capacity(estimated_blocks);

--- a/crates/revx-analysis/src/resource.rs
+++ b/crates/revx-analysis/src/resource.rs
@@ -4,7 +4,6 @@ use std::time::{Duration, Instant};
 const DEFAULT_JOBS: usize = 1;
 const ABSOLUTE_MAX_JOBS: usize = 2;
 const DEFAULT_WALL_SEC: u64 = 180;
-const DEFAULT_RSS_KB: u64 = 8 * 1024;
 const DEFAULT_CPU_SEC: u64 = 180;
 const DEFAULT_NICE: i32 = 5;
 const ABSOLUTE_MAX_RSS_BYTES: u64 = 8 * 1024 * 1024;
@@ -18,40 +17,53 @@ pub struct ProcessResourceLimits {
     pub nice: i32,
 }
 
+fn resolve_jobs(
+    requested: Option<usize>,
+    relaxed: bool,
+    lean: bool,
+    micro: bool,
+    available: usize,
+    job_cap: usize,
+) -> usize {
+    let chosen = match requested {
+        Some(requested) => requested.min(job_cap),
+        None => {
+            if lean || micro || !relaxed {
+                DEFAULT_JOBS
+            } else {
+                job_cap
+            }
+        }
+    };
+    chosen.min(available)
+}
+
 impl ProcessResourceLimits {
     pub fn from_env() -> Self {
-        let job_cap = if std::env::var_os("REVX_FULL_MEM").is_some() {
-            4
-        } else {
-            ABSOLUTE_MAX_JOBS
-        };
-        let jobs = std::env::var("REVX_JOBS")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .filter(|v| *v >= 1)
-            .unwrap_or(DEFAULT_JOBS)
-            .min(job_cap);
+        let relaxed = std::env::var_os("REVX_FULL_MEM").is_some() || revx_core::rss_limit_relaxed();
+        let job_cap = if relaxed { 4 } else { ABSOLUTE_MAX_JOBS };
         let available = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1)
             .max(1);
-        let jobs = jobs.min(available);
+        let requested = std::env::var("REVX_JOBS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|v| *v >= 1);
+        let jobs = resolve_jobs(
+            requested,
+            relaxed,
+            revx_core::lean_mode(),
+            revx_core::micro_mode(),
+            available,
+            job_cap,
+        );
         let wall_sec = std::env::var("REVX_WALL_SEC")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .filter(|v| *v >= 1)
             .unwrap_or(DEFAULT_WALL_SEC);
-        let rss_kb = std::env::var("REVX_RSS_KB")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .or_else(|| {
-                std::env::var("REVX_RSS_MB")
-                    .ok()
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .map(|mb| mb.saturating_mul(1024))
-            })
-            .filter(|v| *v >= 64)
-            .unwrap_or(DEFAULT_RSS_KB);
+        let rss_kb = revx_core::env_rss_kb();
         let cpu_sec = std::env::var("REVX_CPU_SEC")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
@@ -330,4 +342,41 @@ impl AnalysisBudget {
 
 pub fn analysis_worker_count() -> usize {
     ensure_process_resource_limits().jobs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jobs_default_stays_one_in_lean_and_unrelaxed() {
+        for (lean, micro, relaxed) in [
+            (true, false, true),
+            (false, true, true),
+            (false, false, false),
+        ] {
+            assert_eq!(resolve_jobs(None, relaxed, lean, micro, 8, 4), 1);
+        }
+    }
+
+    #[test]
+    fn jobs_relaxed_defaults_to_cap_capped_by_available() {
+        assert_eq!(resolve_jobs(None, true, false, false, 8, 4), 4);
+        assert_eq!(resolve_jobs(None, true, false, false, 2, 4), 2);
+        assert_eq!(resolve_jobs(None, true, false, false, 1, 4), 1);
+        assert_eq!(
+            resolve_jobs(None, true, false, false, 8, ABSOLUTE_MAX_JOBS),
+            2
+        );
+    }
+
+    #[test]
+    fn jobs_explicit_env_wins_and_still_capped() {
+        assert_eq!(resolve_jobs(Some(8), true, false, false, 8, 4), 4);
+        assert_eq!(
+            resolve_jobs(Some(8), false, false, false, 8, ABSOLUTE_MAX_JOBS),
+            2
+        );
+        assert_eq!(resolve_jobs(Some(1), true, false, false, 8, 4), 1);
+    }
 }

--- a/crates/revx-core/src/compound.rs
+++ b/crates/revx-core/src/compound.rs
@@ -481,8 +481,8 @@ fn collect_fat(
             warnings.push(format!("FAT sector {sector} exceeds file size"));
             continue;
         };
-        for chunk in sector_bytes.chunks_exact(4) {
-            fat.push(u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+        for &chunk in sector_bytes.as_chunks::<4>().0 {
+            fat.push(u32::from_le_bytes(chunk));
         }
     }
     Ok(fat)
@@ -503,8 +503,10 @@ fn collect_mini_fat(
         warnings,
     )?;
     Ok(mini_fat_bytes
-        .chunks_exact(4)
-        .map(|chunk| u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|chunk| u32::from_le_bytes(*chunk))
         .collect())
 }
 
@@ -568,7 +570,9 @@ fn parse_directory_entries(
 ) -> Vec<CompoundDirectoryEntry> {
     let mut entries = Vec::new();
     for (index, entry) in directory_bytes
-        .chunks_exact(DIRECTORY_ENTRY_SIZE)
+        .as_chunks::<DIRECTORY_ENTRY_SIZE>()
+        .0
+        .iter()
         .enumerate()
     {
         let object_type = entry[66];
@@ -684,8 +688,8 @@ fn decode_directory_name(entry: &[u8]) -> Option<String> {
     }
     let raw = entry.get(..name_len.saturating_sub(2))?;
     let mut units = Vec::new();
-    for chunk in raw.chunks_exact(2) {
-        units.push(u16::from_le_bytes([chunk[0], chunk[1]]));
+    for &chunk in raw.as_chunks::<2>().0 {
+        units.push(u16::from_le_bytes(chunk));
     }
     String::from_utf16(&units).ok()
 }

--- a/crates/revx-core/src/limits.rs
+++ b/crates/revx-core/src/limits.rs
@@ -2,18 +2,83 @@ use std::sync::OnceLock;
 
 const DEFAULT_RSS_KB: u64 = 8 * 1024;
 
-pub fn env_rss_kb() -> u64 {
-    std::env::var("REVX_RSS_KB")
-        .ok()
+pub fn parse_rss_kb(raw_kb: Option<&str>, raw_mb: Option<&str>) -> Option<u64> {
+    raw_kb
         .and_then(|v| v.parse::<u64>().ok())
         .or_else(|| {
-            std::env::var("REVX_RSS_MB")
-                .ok()
+            raw_mb
                 .and_then(|v| v.parse::<u64>().ok())
                 .map(|mb| mb.saturating_mul(1024))
         })
         .filter(|v| *v >= 64)
-        .unwrap_or(DEFAULT_RSS_KB)
+}
+
+pub fn env_rss_kb() -> u64 {
+    env_rss_kb_parsed().unwrap_or(DEFAULT_RSS_KB)
+}
+
+fn env_rss_kb_parsed() -> Option<u64> {
+    parse_rss_kb(
+        std::env::var("REVX_RSS_KB").ok().as_deref(),
+        std::env::var("REVX_RSS_MB").ok().as_deref(),
+    )
+}
+
+pub fn rss_limit_relaxed() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        env_rss_kb_parsed()
+            .map(|kb| kb > DEFAULT_RSS_KB)
+            .unwrap_or(false)
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AnalysisCaps {
+    pub global_references: Option<usize>,
+    pub cfg_blocks: Option<usize>,
+    pub cfg_instructions: Option<usize>,
+    pub shared_string_map: Option<usize>,
+    pub data_ref_scan_insts: Option<usize>,
+}
+
+pub const ENV_MAX_GLOBAL_REFERENCES: &str = "REVX_MAX_GLOBAL_REFERENCES";
+pub const ENV_MAX_CFG_BLOCKS: &str = "REVX_MAX_CFG_BLOCKS";
+pub const ENV_MAX_CFG_INSTRUCTIONS: &str = "REVX_MAX_CFG_INSTRUCTIONS";
+pub const ENV_MAX_SHARED_STRING_MAP: &str = "REVX_MAX_SHARED_STRING_MAP";
+pub const ENV_MAX_DATA_REF_SCAN_INSTS: &str = "REVX_MAX_DATA_REF_SCAN_INSTS";
+
+pub fn resolve_analysis_caps(
+    global_references: Option<&str>,
+    cfg_blocks: Option<&str>,
+    cfg_instructions: Option<&str>,
+    shared_string_map: Option<&str>,
+    data_ref_scan_insts: Option<&str>,
+) -> AnalysisCaps {
+    fn parse(raw: Option<&str>) -> Option<usize> {
+        raw.and_then(|v| v.parse::<usize>().ok())
+            .filter(|v| *v >= 1)
+    }
+    AnalysisCaps {
+        global_references: parse(global_references),
+        cfg_blocks: parse(cfg_blocks),
+        cfg_instructions: parse(cfg_instructions),
+        shared_string_map: parse(shared_string_map),
+        data_ref_scan_insts: parse(data_ref_scan_insts),
+    }
+}
+
+pub fn analysis_caps() -> AnalysisCaps {
+    static CAPS: OnceLock<AnalysisCaps> = OnceLock::new();
+    *CAPS.get_or_init(|| {
+        resolve_analysis_caps(
+            std::env::var(ENV_MAX_GLOBAL_REFERENCES).ok().as_deref(),
+            std::env::var(ENV_MAX_CFG_BLOCKS).ok().as_deref(),
+            std::env::var(ENV_MAX_CFG_INSTRUCTIONS).ok().as_deref(),
+            std::env::var(ENV_MAX_SHARED_STRING_MAP).ok().as_deref(),
+            std::env::var(ENV_MAX_DATA_REF_SCAN_INSTS).ok().as_deref(),
+        )
+    })
 }
 
 pub fn micro_mode() -> bool {
@@ -61,5 +126,42 @@ pub fn lean_string_limits() -> (usize, usize, usize) {
         (8, 512, 16 * 1024)
     } else {
         (usize::MAX, usize::MAX, usize::MAX)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rss_kb_prefers_kb_and_filters_small() {
+        assert_eq!(parse_rss_kb(Some("128"), Some("512")), Some(128));
+        assert_eq!(parse_rss_kb(None, Some("512")), Some(512 * 1024));
+        assert_eq!(parse_rss_kb(Some("16"), Some("512")), None);
+        assert_eq!(parse_rss_kb(Some("32"), None), None);
+        assert_eq!(parse_rss_kb(Some("abc"), Some("zzz")), None);
+        assert_eq!(parse_rss_kb(None, None), None);
+    }
+
+    #[test]
+    fn rss_relaxed_requires_above_default() {
+        let relaxed = |kb: Option<u64>| kb.map(|v| v > DEFAULT_RSS_KB).unwrap_or(false);
+        assert!(!relaxed(None));
+        assert!(!relaxed(Some(DEFAULT_RSS_KB)));
+        assert!(relaxed(Some(DEFAULT_RSS_KB + 1)));
+    }
+
+    #[test]
+    fn resolve_analysis_caps_parses_and_rejects_invalid() {
+        let caps = resolve_analysis_caps(Some("4096"), Some("0"), Some("x"), None, Some("128"));
+        assert_eq!(caps.global_references, Some(4096));
+        assert_eq!(caps.cfg_blocks, None);
+        assert_eq!(caps.cfg_instructions, None);
+        assert_eq!(caps.shared_string_map, None);
+        assert_eq!(caps.data_ref_scan_insts, Some(128));
+        assert_eq!(
+            resolve_analysis_caps(None, None, None, None, None),
+            AnalysisCaps::default()
+        );
     }
 }

--- a/crates/revx-loader/src/lib.rs
+++ b/crates/revx-loader/src/lib.rs
@@ -5307,8 +5307,10 @@ fn extract_utf16le_strings(base_address: u64, bytes: &[u8]) -> Vec<StringLiteral
                 let char_count = (idx - s) / 2;
                 if char_count >= 4 {
                     let utf16: Vec<u16> = bytes[s..idx]
-                        .chunks_exact(2)
-                        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
+                        .map(|chunk| u16::from_le_bytes(*chunk))
                         .collect();
                     if let Ok(value) = String::from_utf16(&utf16) {
                         out.push(StringLiteral {
@@ -5327,8 +5329,10 @@ fn extract_utf16le_strings(base_address: u64, bytes: &[u8]) -> Vec<StringLiteral
         let char_count = (bytes.len() - s) / 2;
         if char_count >= 4 {
             let utf16: Vec<u16> = bytes[s..]
-                .chunks_exact(2)
-                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|chunk| u16::from_le_bytes(*chunk))
                 .collect();
             if let Ok(value) = String::from_utf16(&utf16) {
                 out.push(StringLiteral {

--- a/crates/revx-workspace/src/lib.rs
+++ b/crates/revx-workspace/src/lib.rs
@@ -16643,8 +16643,10 @@ fn shell_link_utf16_at(
 
 fn decode_utf16le_lossy(bytes: &[u8]) -> String {
     let units = bytes
-        .chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|chunk| u16::from_le_bytes(*chunk))
         .collect::<Vec<_>>();
     String::from_utf16_lossy(&units)
 }
@@ -18820,8 +18822,10 @@ fn dotnet_extract_user_strings(
         };
         if utf16_bytes.len() >= 2 && utf16_bytes.len() % 2 == 0 {
             let units = utf16_bytes
-                .chunks_exact(2)
-                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|chunk| u16::from_le_bytes(*chunk))
                 .collect::<Vec<_>>();
             let raw = String::from_utf16_lossy(&units);
             if !raw.is_empty() {
@@ -28381,8 +28385,10 @@ fn decode_vba_record_string(data: &[u8]) -> Option<String> {
     }
     if data.len().is_multiple_of(2) && data.iter().skip(1).step_by(2).any(|byte| *byte == 0) {
         let units = data
-            .chunks_exact(2)
-            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|chunk| u16::from_le_bytes(*chunk))
             .take_while(|unit| *unit != 0)
             .collect::<Vec<_>>();
         return String::from_utf16(&units)

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+OUT="target/bench-results/$STAMP"
+mkdir -p "$OUT"
+
+run_pass() {
+  local name=$1
+  shift
+  echo "== pass: $name =="
+  env "$@" cargo bench -p revx-analysis --bench analyze -- --save-baseline "$name" 2>&1 | tee "$OUT/$name.log"
+}
+
+run_pass lean
+run_pass fullmem REVX_FULL_MEM=1 REVX_RSS_MB=512
+
+python3 - "$OUT/summary.csv" <<'PY'
+import json, pathlib, sys
+
+out = sys.argv[1]
+root = pathlib.Path("target/criterion")
+rows = ["pass,bench,mean_ns,std_dev_ns"]
+for estimates in sorted(root.glob("*/*/*/estimates.json")):
+    group, bid, baseline = estimates.relative_to(root).parts[:3]
+    if baseline == "new":
+        continue
+    data = json.loads(estimates.read_text())
+    rows.append(
+        f"{baseline},{group}/{bid},"
+        f"{data['mean']['point_estimate']:.0f},"
+        f"{data['std_dev']['point_estimate']:.0f}"
+    )
+pathlib.Path(out).write_text("\n".join(rows) + "\n")
+print("\n".join(rows))
+print(f"saved: {out}")
+PY


### PR DESCRIPTION
## What

按 #29 落地 M3 三件套:

1. **并行度默认值**(`revx-analysis/src/resource.rs`)
   - `REVX_FULL_MEM=1` 或 RSS 上限显式调高(>8MB 默认)时,未设 `REVX_JOBS` 则默认 `min(4, available_parallelism)`
   - lean/micro 模式维持默认 1;显式 `REVX_JOBS` 行为不变(仍受 cap 约束)
   - 决策逻辑抽成纯函数 `resolve_jobs`,3 个单测覆盖 lean/relaxed/explicit 三类路径

2. **分析上限 env 可配置化**(`revx-core/src/limits.rs` + `revx-analysis/src/lib.rs`)
   - 新增 `analysis_caps()`:`REVX_MAX_GLOBAL_REFERENCES`(512)、`REVX_MAX_CFG_BLOCKS`(48)、`REVX_MAX_CFG_INSTRUCTIONS`(192)、`REVX_MAX_SHARED_STRING_MAP`(64)、`REVX_MAX_DATA_REF_SCAN_INSTS`(256)
   - 显式 env 值优先于 lean 钳制;不设 env 时行为与改前逐位一致
   - 解析抽成纯函数 `resolve_analysis_caps`,无效值(0/非数字)安全忽略

3. **基准设施**
   - `crates/revx-analysis/benches/analyze.rs`:criterion,testkit 合成 ELF,Fast vs Full
   - `scripts/bench.sh`:lean + fullmem 两轮,`--save-baseline`,输出 CSV(`target/bench-results/<stamp>/summary.csv`)
   - `[profile.bench]` 用 opt-level 3 + thin LTO(避免继承 release 的 opt-level z 影响测量)

## Why

- 大内存场景默认单线程浪费多核;分析大二进制想提高深度只能改代码重编
- 无基准设施,性能回归不可见

## 附带修复

- arm64 CFG 容量估计 `clamp(4/16, limit)` 在 limit 低于下限时 panic(`min > max`)——env 打开后可触达,改为 `.max(lo).min(limit)` 平滑降级(端到端验证:极端 caps 下 analyze 正常完成且结果随 caps 变化)
- RSS env 解析去重:resource.rs 改用 `revx_core::env_rss_kb`(行为逐位一致)

## 验证

- `cargo fmt --all -- --check` / `clippy -D warnings` / `cargo test --workspace --all-targets` 全绿(239 passed)
- 端到端:临时工作区分析真实 .so,极端低 caps 与默认 caps 的 survey 结果按预期分化;`scripts/bench.sh` 产出 CSV 基线
- 明确不做:逐函数并行化(高风险,记录在 Issue 作后续方向)

Fixes #29