### PR TITLE
refactor: 跨 crate 重复逻辑收敛 (M4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 name = "revx"
 version = "0.1.0"
 dependencies = [
+ "revx-core",
  "revx-query",
  "serde_json",
 ]
@@ -878,6 +879,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "toml",
  "uuid",
 ]
 
@@ -955,6 +957,7 @@ version = "0.1.0"
 name = "revx-query"
 version = "0.1.0"
 dependencies = [
+ "revx-core",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/revx-app/Cargo.toml
+++ b/crates/revx-app/Cargo.toml
@@ -6,5 +6,6 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
+revx-core = { path = "../revx-core" }
 serde_json = { workspace = true }
 revx-query = { path = "../revx-query" }

--- a/crates/revx-app/src/main.rs
+++ b/crates/revx-app/src/main.rs
@@ -278,17 +278,9 @@ fn resolve_engine() -> Result<PathBuf, String> {
 
 fn workspace_from_cwd() -> Result<QueryWorkspace, String> {
     let cwd = env::current_dir().map_err(|e| e.to_string())?;
-    let mut dir = cwd.as_path();
-    loop {
-        if dir.join(".revx").exists() {
-            return QueryWorkspace::open(dir).map_err(|e| e.to_string());
-        }
-        match dir.parent() {
-            Some(parent) if parent != dir => dir = parent,
-            _ => break,
-        }
-    }
-    Err(format!("no revx workspace in {} or parents", cwd.display()))
+    let root = revx_core::find_workspace_root(&cwd)
+        .ok_or_else(|| format!("no revx workspace in {} or parents", cwd.display()))?;
+    QueryWorkspace::open(&root).map_err(|e| e.to_string())
 }
 
 fn parse_usize_flag(args: &[String], flag: &str, default: usize) -> usize {

--- a/crates/revx-core/Cargo.toml
+++ b/crates/revx-core/Cargo.toml
@@ -9,4 +9,5 @@ authors.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+toml.workspace = true
 uuid.workspace = true

--- a/crates/revx-core/src/lib.rs
+++ b/crates/revx-core/src/lib.rs
@@ -2,8 +2,10 @@ pub mod compound;
 pub mod intern;
 pub mod limits;
 pub mod model;
+pub mod project;
 
 pub use compound::*;
 pub use intern::*;
 pub use limits::*;
 pub use model::*;
+pub use project::*;

--- a/crates/revx-core/src/project.rs
+++ b/crates/revx-core/src/project.rs
@@ -1,0 +1,78 @@
+use crate::model::ProjectConfig;
+use std::path::{Path, PathBuf};
+
+pub fn find_workspace_root(start: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start);
+    while let Some(current) = dir {
+        if current.join(".revx").exists() {
+            return Some(current.to_path_buf());
+        }
+        dir = current.parent().filter(|parent| *parent != current);
+    }
+    None
+}
+
+pub fn parse_address(value: &str) -> Option<u64> {
+    let trimmed = value.trim();
+    if let Some(hex) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        return u64::from_str_radix(hex, 16).ok();
+    }
+    if trimmed.chars().all(|c| c.is_ascii_hexdigit())
+        && trimmed.chars().any(|c| c.is_ascii_alphabetic())
+    {
+        return u64::from_str_radix(trimmed, 16).ok();
+    }
+    trimmed.parse::<u64>().ok()
+}
+
+pub fn parse_project_config(raw: &str) -> Result<ProjectConfig, String> {
+    toml::from_str(raw).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn parse_address_accepts_prefixed_bare_hex_and_decimal() {
+        assert_eq!(parse_address("0x401000"), Some(0x401000));
+        assert_eq!(parse_address("0X401000"), Some(0x401000));
+        assert_eq!(parse_address("deadbeef"), Some(0xdeadbeef));
+        assert_eq!(parse_address("12345"), Some(12345));
+        assert_eq!(parse_address("  0x10 "), Some(16));
+        assert_eq!(parse_address(""), None);
+        assert_eq!(parse_address("xyz"), None);
+        assert_eq!(parse_address("0xzz"), None);
+    }
+
+    #[test]
+    fn find_workspace_root_walks_up_to_revx_dir() {
+        let base = std::env::temp_dir().join(format!("revx-root-{}", std::process::id()));
+        let nested = base.join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+        assert_eq!(find_workspace_root(&nested), None);
+        fs::create_dir_all(base.join(".revx")).unwrap();
+        assert_eq!(
+            find_workspace_root(&nested),
+            Some(base.join(".revx").parent().unwrap().to_path_buf())
+        );
+        fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn parse_project_config_reads_toml_document() {
+        let raw = "schema_version = 4\nname = \"demo\"\ncreated_at = \"2026-08-21T00:00:00Z\"\n";
+        let cfg = parse_project_config(raw).unwrap();
+        assert_eq!(cfg.schema_version, 4);
+        assert_eq!(cfg.name, "demo");
+        assert_eq!(cfg.primary_binary, None);
+        let raw = format!("{raw}primary_binary = \"libdemo.so\"\n");
+        let cfg = parse_project_config(&raw).unwrap();
+        assert_eq!(cfg.primary_binary.as_deref(), Some("libdemo.so"));
+        assert!(parse_project_config("broken").is_err());
+    }
+}

--- a/crates/revx-engine/src/main.rs
+++ b/crates/revx-engine/src/main.rs
@@ -1570,17 +1570,9 @@ fn render_mcp_host_config(host: McpHost, engine: &Path, workspace: &Path) -> Str
 
 fn workspace_from_cwd() -> Result<Workspace> {
     let cwd = std::env::current_dir()?;
-    let mut dir = cwd.as_path();
-    loop {
-        if dir.join(".revx").exists() {
-            return Workspace::open(dir);
-        }
-        match dir.parent() {
-            Some(parent) if parent != dir => dir = parent,
-            _ => break,
-        }
-    }
-    anyhow::bail!("no revx workspace in {} or parents", cwd.display())
+    let root = revx_core::find_workspace_root(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("no revx workspace in {} or parents", cwd.display()))?;
+    Workspace::open(&root)
 }
 
 fn workspace_parent_from_cwd() -> Result<PathBuf> {

--- a/crates/revx-query/Cargo.toml
+++ b/crates/revx-query/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
+revx-core = { path = "../revx-core" }
 rusqlite = { workspace = true, default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/revx-query/src/lib.rs
+++ b/crates/revx-query/src/lib.rs
@@ -1,3 +1,4 @@
+use revx_core::{PROJECT_SCHEMA_VERSION, ProjectConfig, parse_address, parse_project_config};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -5,8 +6,6 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-const PROJECT_SCHEMA_VERSION: u32 = 4;
 
 type FunctionLookupRow = (
     String,
@@ -22,14 +21,6 @@ type FunctionLookupRow = (
 #[derive(Clone)]
 pub struct QueryWorkspace {
     root: PathBuf,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ProjectConfig {
-    pub schema_version: u32,
-    pub name: String,
-    pub created_at: String,
-    pub primary_binary: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -159,7 +150,7 @@ impl QueryWorkspace {
     pub fn project_config(&self) -> Result<ProjectConfig> {
         let path = self.root.join("project.toml");
         let raw = fs::read_to_string(&path)?;
-        let cfg = parse_project_toml(&raw)?;
+        let cfg = parse_project_config(&raw).map_err(QueryError)?;
         if cfg.schema_version != PROJECT_SCHEMA_VERSION {
             return Err(QueryError(format!(
                 "unsupported workspace schema_version={} at {}; expected {}",
@@ -573,17 +564,6 @@ fn map_reference(row: &rusqlite::Row<'_>) -> rusqlite::Result<ReferenceHit> {
     })
 }
 
-fn parse_address(query: &str) -> Option<u64> {
-    let q = query.trim();
-    if let Some(hex) = q.strip_prefix("0x").or_else(|| q.strip_prefix("0X")) {
-        return u64::from_str_radix(hex, 16).ok();
-    }
-    if q.chars().all(|c| c.is_ascii_hexdigit()) && q.chars().any(|c| c.is_ascii_alphabetic()) {
-        return u64::from_str_radix(q, 16).ok();
-    }
-    q.parse::<u64>().ok()
-}
-
 fn read_json_file<T: serde::de::DeserializeOwned>(
     root: &Path,
     relative: Option<&str>,
@@ -612,55 +592,6 @@ fn rank_name(query: &str, value: &str) -> i32 {
     } else {
         0
     }
-}
-
-fn parse_project_toml(raw: &str) -> Result<ProjectConfig> {
-    let mut schema_version = None;
-    let mut name = None;
-    let mut created_at = None;
-    let mut primary_binary = None;
-    for line in raw.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
-        };
-        let key = key.trim();
-        let value = value.trim();
-        match key {
-            "schema_version" => {
-                schema_version = value.parse::<u32>().ok();
-            }
-            "name" => name = Some(unquote(value)),
-            "created_at" => created_at = Some(unquote(value)),
-            "primary_binary" => {
-                if value == "null" {
-                    primary_binary = None;
-                } else {
-                    primary_binary = Some(unquote(value));
-                }
-            }
-            _ => {}
-        }
-    }
-    Ok(ProjectConfig {
-        schema_version: schema_version
-            .ok_or_else(|| QueryError("missing schema_version".into()))?,
-        name: name.ok_or_else(|| QueryError("missing name".into()))?,
-        created_at: created_at.ok_or_else(|| QueryError("missing created_at".into()))?,
-        primary_binary,
-    })
-}
-
-fn unquote(value: &str) -> String {
-    let v = value.trim();
-    if v.len() >= 2 && v.starts_with('"') && v.ends_with('"') {
-        let inner = &v[1..v.len() - 1];
-        return inner.replace("\\\"", "\"").replace("\\\\", "\\");
-    }
-    v.to_string()
 }
 
 fn toml_string(value: &str) -> String {

--- a/crates/revx-workspace/src/lib.rs
+++ b/crates/revx-workspace/src/lib.rs
@@ -17,7 +17,7 @@ use revx_core::{
     ObjectSignatureScanResponse, PROJECT_SCHEMA_VERSION, ProjectConfig, PseudocodeUnit, Reference,
     Report, SearchBytesResponse, StringLiteral, Survey, SymbolicConstraint, SymbolicSolveResponse,
     SymbolicSolveStatus, SymbolicVariable, TraceEvent, TypeDef, TypeSource, UniversalObject,
-    Variable, is_compound_file,
+    Variable, is_compound_file, parse_address, parse_project_config,
 };
 use rusqlite::{Connection, OptionalExtension, params};
 use ruzstd::decoding::StreamingDecoder as ZstdDecoder;
@@ -333,8 +333,8 @@ impl Workspace {
         let path = self.root.join("project.toml");
         let raw = fs::read_to_string(&path)
             .with_context(|| format!("failed to read {}", path.display()))?;
-        let cfg: ProjectConfig =
-            toml::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))?;
+        let cfg = parse_project_config(&raw)
+            .map_err(|error| anyhow::anyhow!("failed to parse {}: {error}", path.display()))?;
         if cfg.schema_version != PROJECT_SCHEMA_VERSION {
             anyhow::bail!(
                 "unsupported workspace schema_version={} at {}; expected {}. Re-run `revx init` and re-analyze in a fresh workspace.",
@@ -30090,18 +30090,6 @@ fn ratio(count: usize, total: usize) -> f64 {
         0.0
     } else {
         count as f64 / total as f64
-    }
-}
-
-fn parse_address(value: &str) -> Option<u64> {
-    let trimmed = value.trim();
-    if let Some(hex) = trimmed
-        .strip_prefix("0x")
-        .or_else(|| trimmed.strip_prefix("0X"))
-    {
-        u64::from_str_radix(hex, 16).ok()
-    } else {
-        trimmed.parse().ok()
     }
 }
 


### PR DESCRIPTION
## What

按 #31 收敛跨 crate 重复逻辑,新增 `revx_core::project` 模块:

1. **`find_workspace_root(start)`**:`revx-app` 与 `revx-engine` 的 `workspace_from_cwd` 原各有一份"从 cwd 逐级向上找 `.revx`"循环,现共享同一实现,各自只保留错误包装(文案不变)
2. **`parse_address`**:query 与 workspace 两份实现统一为超集语义(`0x`/`0X` 前缀 → 无前缀含字母 hex → 十进制)。行为影响:workspace 侧地址参数从此也接受无前缀 hex(改进)
3. **`parse_project_config`**:project.toml 解析统一走 toml crate。query 删除手写逐行解析器、本地 `ProjectConfig` DTO(改用 core 规范类型)和重复的 `PROJECT_SCHEMA_VERSION` 常量

## 与 Issue 的偏差(改进)

- `find_workspace_root` 放在 `revx-core` 而非 Issue 里写的 `revx-workspace`:app 原本不依赖 workspace crate,放 core 让 app 只新增轻量 core 依赖,不引入 rusqlite 依赖边
- `text_preview` 不合并(Issue 已记录理由):daemon 版是 `(&str, limit)` 截断,workspace 版是 `&[u8]` 文本性校验,契约不同
- query 的 `created_at` 输出从文件原串变为 chrono 规范化 RFC3339(写入端本就是 RFC3339,实测输出一致,见端到端验证)

## 验证

- fmt / clippy(-D warnings)/ `cargo test --workspace --all-targets` 全绿(242 passed,新增 3 个 core 单测)
- 端到端:临时工作区 `revx init` → 子目录 `revx status`(根上溯 + project.toml 解析)→ `revx analyze` → `revx func 0xbe0 / be0 / 3040` 三种写法解析到同一函数

Fixes #31